### PR TITLE
Create an index of existing HIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # HIP
+
 Helium Improvement Proposals
+
+More details on process and how to participate to come.
+
+## Index of proposals
+
+| ID | Title | Status |
+| -- | ----- | ------ |
+| 1  | [Longfi and LoRaWAN](https://github.com/helium/HIP/blob/master/0001-longfi-and-lorawan.md) | Merged |
+| 2  | [Sign miner](https://github.com/helium/HIP/blob/master/0002-sign-miner.md) | Merged |
+| 3  | [Over-the-air miner upates](https://github.com/helium/HIP/blob/master/0003-miner-update.md) | Merged |
+| 4  | [Data credits](https://github.com/helium/HIP/blob/master/0004-data-credits.md) | Merged |
+| 4bis | [Chain multisig](https://github.com/helium/HIP/blob/89075b125fc32f95bb8810686ad8062aa2dd6a59/0004-chain-var-multisig.md) | Discussion? |
+| 5  | [PoC fairness/epoch challenge limit](https://github.com/helium/HIP/blob/724bc34a277ad98ca076b5e838184f47c840fabd/0005-poc-fairness.md) | Discussion |
+| 6  | [Reward ramp for packet](https://github.com/helium/HIP/blob/60ba6cb841d3ef66020a8504070f7016d20ef5ab/0006-reward-ramp-for-packets.md) | Discussion? | 
+| 7  | [Process for managing Helium Improvement Proposals](https://github.com/helium/HIP/blob/a2e5561c9cacdd93c970f99029947895693d5aac/0007-managing-hip-process.md) | Discussion |
+| 8  | [LoRaWAN packet routing](https://github.com/helium/HIP/blob/c2f3ce61466b003731bb967959ca8b6e7706fca5/0008-lorawan-routing.md) | Discussion? |
+| 9  | [Ensuring trust for non-Helium hotspots](https://github.com/helium/HIP/blob/7b715a0614d4c529144e1d6c0083ee8b38c05b29/0009-non-helium-hotspots.md) | Discussion |
+
+


### PR DESCRIPTION
I've attempted to index all the of the past and current proposals, although it's pretty messy. I think some of these were re-numbered, or might not be active at all. I think we have two HIP4s. HIPs 8 and 9 also predate 5-7 which is a little confusing.

Some suggestions for organizing up this repository:

* We should start merging all the [open HIP PRs](https://github.com/helium/HIP/pulls) so that all of the `.md` files are in one git tree
* Once those `.md` files are are merged into master, it'll be possible to create discussion issues for each open HIP. Then we can link to that discussion issue from the HIP's canonical `.md` file. Linking into a git subtree like I'm doing currently isn't very sustainable, since you won't see the most recent version.
* Clean up the HIP numbering (again)
* The proposals that have been merged should link to the relevant commits and/or blockchain chainvar transactions.

cc @PharkMillups