### PR TITLE
DC Expensing Amendment to Charge for ACK frames

### DIFF
--- a/0004-expensing-data-credits-for-lorawan.md
+++ b/0004-expensing-data-credits-for-lorawan.md
@@ -14,15 +14,20 @@ LoRaWAN/MAC header, and the MAC Payload, FOpts and FRMPayload there are several
 ways of deciding how to meter bytes.
 
 This proposal here is to charge for **FOpts** and **FRMPayload** exclusively,
-but to charge 1 DC per Join uplink and 1 DC per Join-Accept downlink.
+but to charge 1 DC per Join uplink and 1 DC per Join-Accept downlink. In
+addition, any packet up or down will cost at
+least 1 DC.
 
-FOpts are fifteen optional bytes used almost exclusiveely for MAC Commands.
+FOpts are fifteen optional bytes used almost exclusively for MAC Commands.
 
 FRMPayload are essentially the application data.
 
 By defining things this way, we can keep the data calculations very simple for
 network users, while also protecting against simple ways to move additional
 data "for free".
+
+Finally, the minimum charge of 1 DC for any packet assures that ACK packets
+are not free despite having potentially empty FOpt or FRMPayload fields. 
 
 Meanwhile, for network operators, there may be some confusion as "bytes on 
 [LoRaWAN] air" do not match 1:1 bytes over the Internet backhaul. Radio packet

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ More details on process and how to participate to come.
 | 1  | [Longfi and LoRaWAN](https://github.com/helium/HIP/blob/master/0001-longfi-and-lorawan.md) | Merged |
 | 2  | [Sign miner](https://github.com/helium/HIP/blob/master/0002-sign-miner.md) | Merged |
 | 3  | [Over-the-air miner upates](https://github.com/helium/HIP/blob/master/0003-miner-update.md) | Merged |
-| 4  | [Exensing Data Credits for LoRaWAN Traffic](https://github.com/helium/HIP/blob/master/0004-data-credits.md) | Merged |
+| 4  | [Expensing Data Credits for LoRaWAN Traffic](https://github.com/helium/HIP/blob/master/0004-data-credits.md) | Merged |
 | 4bis | [Chain multisig](https://github.com/helium/HIP/blob/89075b125fc32f95bb8810686ad8062aa2dd6a59/0004-chain-var-multisig.md) | Discussion? |
 | 5  | [PoC fairness/epoch challenge limit](https://github.com/helium/HIP/blob/724bc34a277ad98ca076b5e838184f47c840fabd/0005-poc-fairness.md) | Discussion |
 | 6  | [Reward ramp for packet](https://github.com/helium/HIP/blob/60ba6cb841d3ef66020a8504070f7016d20ef5ab/0006-reward-ramp-for-packets.md) | Discussion? | 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ More details on process and how to participate to come.
 | 1  | [Longfi and LoRaWAN](https://github.com/helium/HIP/blob/master/0001-longfi-and-lorawan.md) | Merged |
 | 2  | [Sign miner](https://github.com/helium/HIP/blob/master/0002-sign-miner.md) | Merged |
 | 3  | [Over-the-air miner upates](https://github.com/helium/HIP/blob/master/0003-miner-update.md) | Merged |
-| 4  | [Data credits](https://github.com/helium/HIP/blob/master/0004-data-credits.md) | Merged |
+| 4  | [Exensing Data Credits for LoRaWAN Traffic](https://github.com/helium/HIP/blob/master/0004-data-credits.md) | Merged |
 | 4bis | [Chain multisig](https://github.com/helium/HIP/blob/89075b125fc32f95bb8810686ad8062aa2dd6a59/0004-chain-var-multisig.md) | Discussion? |
 | 5  | [PoC fairness/epoch challenge limit](https://github.com/helium/HIP/blob/724bc34a277ad98ca076b5e838184f47c840fabd/0005-poc-fairness.md) | Discussion |
 | 6  | [Reward ramp for packet](https://github.com/helium/HIP/blob/60ba6cb841d3ef66020a8504070f7016d20ef5ab/0006-reward-ramp-for-packets.md) | Discussion? | 


### PR DESCRIPTION
Our current definition for how DCs are expensed for LoRaWAN traffic did not account for "empty" acknowledgement packets, ie: ACK frames that do not have FRMPayload or FOpts. I do not believe our intention was to make ACKs free, so this has been corrected.

In addition, article `0004` is renamed from the generic "data credits" to "expensing data credits for lorawan", as the article itself is not nearly as broad as the original title suggested.