### PR TITLE
HIP20: mark as Approved

### DIFF
--- a/0020-hnt-max-supply.md
+++ b/0020-hnt-max-supply.md
@@ -4,6 +4,7 @@
 - Start Date: November 4, 2020
 - Category: Economic
 - Tracking Issue: [#73](https://github.com/helium/HIP/issues/73)
+- Status: Approved
 
 # Summary
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have questions or feedback, please ask in [#hips in the community Discord
 | 16 | [Remove Score from Consensus Group Elections](https://github.com/helium/HIP/blob/master/0016-random-consensus-group-election.md) | [Approved](https://github.com/helium/HIP/issues/55) |
 | 17 | [Hex Density-based Transmit Reward Scaling](https://github.com/helium/HIP/blob/master/0017-hex-density-based-transmit-reward-scaling.md) | [Approved](https://github.com/helium/HIP/issues/60) |
 | 18 | [Remove Oracle Forecast for DC Burn](https://github.com/helium/HIP/blob/master/0018-remove-oracle-forecast-for-dc-burn.md) | [In Discussion](https://github.com/helium/HIP/issues/60) |
-| 20 | [HNT Max Supply](https://github.com/helium/HIP/blob/master/0020-hnt-max-supply.md) | [In Discussion](https://github.com/helium/HIP/issues/73) |
+| 20 | [HNT Max Supply](https://github.com/helium/HIP/blob/master/0020-hnt-max-supply.md) | [Approved](https://github.com/helium/HIP/issues/73) |
 | 21 | [PoC Link Layer Upgrades](https://github.com/helium/HIP/blob/master/0021-poc-link-layer.md) | [In Discussion](https://github.com/helium/HIP/issues/78) |
 
 ### Status key


### PR DESCRIPTION
Related to HIP20 #73 

I'm reposting the rationale I posted in [a comment on the above issue](https://github.com/helium/HIP/issues/73#issuecomment-730473527), for posterity: 

> I am pleased to formally recognize that rough consensus has been achieved on this proposal and I'll be marking it as approved, with the first halving date as-proposed for August 1st, 2020. On behalf of the community I'm also requesting the core development team begin any necessary engineering work.
>
> In unscientific Discord polling, HIP20 had 99% support. Those poll numbers also pretty accurately reflect what I've observed in conversations here, in Discord, and in private conversations with interested parties who do not follow the day-to-day of community governance.
>
> This proposal was circulated widely. Beyond GitHub, Discord and the community calls, Helium Inc sent push notifications to all iOS/Android app users and mentioned it in multiple email newsletters. I feel confident we've tried to reach everyone who would have an opinion on this.
>
> Thank you to everyone who has provided feedback on this proposal here, on Discord, and on yesterday's community call. If you missed it, notes and a video recording are available here: https://jamiedubs.com/helium-community-call/
> 
> A quick recap of timeline and discussion:
>
> * August 2020 – Idea first suggested and discused in Discord. Discussion and modeling of options, e.g. continuous deflation vs. annual 10% reduction vs. bi-annual halvings, etc
> * 2020/11/04 – HIP formally submitted: https://github.com/helium/HIP/pull/72
> * 2020/11/04 – proposal shared widely by Helium Inc via iOS/Android push notifications, an app that is used by presumably all hotspot owners and hosts: https://discord.com/channels/404106811252408320/730418759298318346/773642730412441671
> * 2020/11/09 – Ad-hoc community call organized by @JMF to discuss: https://discord.com/channels/404106811252408320/773639684366008370/775391966417911809
> * 2020/11/11 straw-man poll about what date change should take effect– https://discord.com/channels/404106811252408320/773639684366008370/776110724954849290
> * 2020/11/18 – pre-meeting straw-man poll about approval, disapproval, or change date: https://discord.com/channels/404106811252408320/773639684366008370/778649670876004383
>
>  Poll summaries as of writing:
> * 68/69 approve overall (99%)
> *  60/69 approve as-is (87%) – meaning 2020/8/1 halving date



