### PR TITLE
Mark Nebra, SyncroB.it & RAK as approved third-party manufacturers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ If you have questions or feedback, please ask in [#hip-open-discussion in the co
 
 | Name | Date | Status |
 | ---- | ---- | ------ |
-| [Nebra Ltd](https://github.com/helium/HIP/blob/master/0019-third-party-manufacturers/nebra-ltd.md) | 2020-12-10 | [In Discussion](https://github.com/helium/HIP/pull/93)
-| [SyncroB.it](https://github.com/helium/HIP/blob/master/0019-third-party-manufacturers/syncrobit.md) | 2020-12-14 | [In Discussion](https://github.com/helium/HIP/pull/96)
-| [RAK Wireless](https://github.com/helium/HIP/blob/master/0019-third-party-manufacturers/rak-wireless.md) | 2020-12-29 | [In Discussion](https://github.com/helium/HIP/pull/103)
+| [Nebra Ltd](https://github.com/helium/HIP/blob/master/0019-third-party-manufacturers/nebra-ltd.md) | 2020-12-10 | [Approved](https://github.com/helium/HIP/pull/93)
+| [SyncroB.it](https://github.com/helium/HIP/blob/master/0019-third-party-manufacturers/syncrobit.md) | 2020-12-14 | [Approved](https://github.com/helium/HIP/pull/96)
+| [RAK Wireless](https://github.com/helium/HIP/blob/master/0019-third-party-manufacturers/rak-wireless.md) | 2020-12-29 | [Approved](https://github.com/helium/HIP/pull/103)
 
 
 ## Status key


### PR DESCRIPTION
Per conversations in Discord and informal polling, there is wide support for approving all 3 of **Nebra Ltd**, **SyncroB.it** and **RAK Wireless** as third-party manufacturers of Helium-compatible hotspots.

On behalf of the community I request that Helium Inc get in touch and arrange for ongoing key issuance. I expect more detail about the key-sharing process will be added to [HIP19](https://github.com/helium/HIP/issues/87) as the details are fleshed out.