### PR TITLE
Amend HIP19 template to add more detailed customer support and dashboard requirements

### DIFF
--- a/0019-third-party-manufacturers/TEMPLATE.md
+++ b/0019-third-party-manufacturers/TEMPLATE.md
@@ -24,8 +24,7 @@ How are you planning to handle customer support for your products? For how long?
 
 Please include how you plan on supporting the ongoing e-commerce store and community feedback in Discord.
 
-Makers are required to maintain and staff a Discord channel to communicate with the community, respond in a timely manner (1 business day), able to provide detailed updates during pre-order period, and communicate in an official capacity on manufacturing status (blog post, website, store page are examples of “official” outlets).
-
+Manufacturers are required to maintain and staff a Discord channel to communicate with the community and respond in a timely manner (1 business day). Additionally, manufacturers are expected to provide detailed updates during any pre-order periods, and communicate in an official capacity on manufacturing status. Blog posts, official website, or store pages are examples of "official" outlets for sharing updates.
 
 ## Hardware Security
 
@@ -41,7 +40,8 @@ The community is concerned about devices that can be easily hacked, specifically
 Have you built and delivered hardware projects before? If yes, how did it go, and how many did you make? If not, from whom will you get help? This is the single largest risk with most hardware ventures. If possible please provide information about your manufacturing partners and supply chain.
 
 ## Hotspot Fleet Management
-Please include a new section titled “Hotspot Fleet management plan” and outline how you plan on supporting Hotspot firmware updates, deployment, and rollback. In addition to a plan, please include how you plan on accomplishing/creating this dashboard. This can be a Maker-supplied support dashboard, or a compatible Hotspot fleet management dashboard.
+
+Please describe how you plan on supporting firmware updates, deployment, and rollback. In addition to a plan, please include how you plan on accomplishing/creating this dashboard. This can be a Maker-supplied support dashboard, or a compatible Hotspot fleet management dashboard.
 
 
 ## Proof of Identity

--- a/0019-third-party-manufacturers/TEMPLATE.md
+++ b/0019-third-party-manufacturers/TEMPLATE.md
@@ -22,6 +22,11 @@ Your time to shine! What are you building? What’s so great about it? Do you ha
 
 How are you planning to handle customer support for your products? For how long? How are you planning to handle repairs and replacements?
 
+Please include how you plan on supporting the ongoing e-commerce store and community feedback in Discord.
+
+Makers are required to maintain and staff a Discord channel to communicate with the community, respond in a timely manner (1 business day), able to provide detailed updates during pre-order period, and communicate in an official capacity on manufacturing status (blog post, website, store page are examples of “official” outlets).
+
+
 ## Hardware Security
 
 The community is concerned about devices that can be easily hacked, specifically by copying their `swarm_key` files. Applications should include plan for how the devices will be secured, potentially including:
@@ -34,6 +39,10 @@ The community is concerned about devices that can be easily hacked, specifically
 ## Manufacturing Information
 
 Have you built and delivered hardware projects before? If yes, how did it go, and how many did you make? If not, from whom will you get help? This is the single largest risk with most hardware ventures. If possible please provide information about your manufacturing partners and supply chain.
+
+## Hotspot Fleet Management
+Please include a new section titled “Hotspot Fleet management plan” and outline how you plan on supporting Hotspot firmware updates, deployment, and rollback. In addition to a plan, please include how you plan on accomplishing/creating this dashboard. This can be a Maker-supplied support dashboard, or a compatible Hotspot fleet management dashboard.
+
 
 ## Proof of Identity
 


### PR DESCRIPTION
We propose today an amendment to HIP-19 to expand support requirements of Makers on the Helium network.

Today, Helium Inc supplies the firmware image and the OTA capabilities for Helium Hotspots and RAK Hotspot Miners. And some makers approved to date are also planning on developing their own Management Dashboard solution to accomplish the same (some with additional features). Bobcat, Syncrob.it, and Nebra all are planning to ship their respective Hotspots with the firmware support.

To ensure customer success and to maintain stability of the Helium Network (meaning the entire fleet has the latest updates), we’d like to amend HIP-19 to include supporting Hotspot-firmware update management, whether it is a Maker-supplied support dashboard, or a compatible Hotspot fleet management dashboard.

When submitting the proposal, please include a new section titled “Hotspot Fleet management plan” and outline how you plan on supporting Hotspot firmware updates, deployment, and rollback.

In addition, please include how you plan on supporting the ongoing e-commerce store and community feedback in Discord.

Makers are required to maintain and staff a Discord channel to communicate with the community, respond in a timely manner (1 business day), able to provide detailed updates during pre-order period, and communicate in an official capacity on manufacturing status (blog post, website, store page are examples of “official” outlets).


Ed: 
* rendered view of complete new template: https://github.com/helium/HIP/blob/ct/hip-19-amendment/0019-third-party-manufacturers/TEMPLATE.md
* diff https://github.com/helium/HIP/pull/141/files
