### PR TITLE
Mark LongAP HIP19 application as approved

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you have questions or feedback, please ask in [#hip-open-discussion in the co
 | [RAK Wireless](https://github.com/helium/HIP/blob/master/0019-third-party-manufacturers/rak-wireless.md) | 2020-12-29 | [Approved](https://github.com/helium/HIP/pull/103) |
 | [EasyLinkin (Bobcat)](https://github.com/helium/HIP/blob/master/0019-third-party-manufacturers/easylinkin.md) | 2021-01-12 | [Approved](https://github.com/helium/HIP/pull/107) |
 | [Kerlink](https://github.com/BenoitDuffez/HIP/blob/hip19-kerlink/0019-third-party-manufacturers/kerlink.md) | 2021-02-24 | [Approved](https://github.com/helium/HIP/pull/121) |
-| [HeNet BV/LongAP](https://github.com/HeNet/HIP/blob/feature/hip19-henet-application/0019-third-party-manufacturers/henet.md) | 2021-03-16 | [In Discussion](https://github.com/helium/HIP/pull/137) |
+| [HeNet BV/LongAP](https://github.com/HeNet/HIP/blob/feature/hip19-henet-application/0019-third-party-manufacturers/henet.md) | 2021-03-16 | [Approved](https://github.com/helium/HIP/pull/137) |
 | [Smart Mimic](https://github.com/onterferon/HIP/blob/master/0019-third-party-manufacturers/Smart-Mimic.md) | 2021-03-25 | [In Discussion](https://github.com/helium/HIP/pull/138) |
 | [Browan](https://github.com/browanofficial/HIP/blob/patch-1/0019-third-party-manufacturers/Browan-Cellular-Gateway.md) | 2021-03-26 | [In Discussion](https://github.com/helium/HIP/pull/139) |
 


### PR DESCRIPTION
Reposting my comment on their application PR: https://github.com/helium/HIP/pull/137#issuecomment-819696961

In recognition of:

- [x] Support from the Helium community, as evidenced by discussions and informal polling on GitHub and Discord
- [x] Identity verification by DeWi (above)
- [x] Regulatory compliance (CE approval)
- [x] Hardware/software/security review of prototype (confirmed by Helium Inc)

I am pleased to memorialize community consensus for approving **HeNet/LongAP** as a third-party manufacturer of Helium-compatible hotspots by marking this proposal approved ✅ 
