### PR TITLE
Rewrite HIP31 with Token Lock rather than Token Burn mechanism

### DIFF
--- a/0031-governance-by-token-burn.md
+++ b/0031-governance-by-token-burn.md
@@ -1,27 +1,35 @@
-## HIP31: Governance by token burn
+# HIP 31: Governance by Token Lock
 
-- Authors: [@tjmcc](Tushar#5143), Shayon Sengupta
+- Authors: Tushar Jain, Shayon Sengupta
 - Start Date: November 14, 2020
 - Category: Governance
-- Original HIP PR: https://github.com/helium/HIP/pull/182
+- Original PR: TBD
 - Tracking Issue: TBD
-- Status: In Discussion
 
-# Summary
+## Summary
 [summary]: #summary
 
-This proposal suggests a governance mechanism for on chain voting for chain variables.
+This proposal suggests on-chain governance voting for implementations of chain variables and protocol upgrades.
+
 
 # Motivation
 [motivation]: #motivation
 
-On chain governance helps make governance decisions transparent and permissionless to influence. It is intended to give control of the protocol to the community.
+On-chain governance helps make governing decisions open and transparent. It is intended to support decentralization of the protocol governance to the community as the Helium protocol continues its journey toward complete decentralization.
 
-Traditionally, on chain governance has meant one token one vote. This is vulnerable to people borrowing tokens to vote with them. With the low voter turnout seen in most other protocols, this attack vector on governance is fairly easy to execute.
+Traditionally, on-chain governance had the following features:
 
-One token one vote also concentrates voting power in the hands of whales and early miners. This can lead to smaller holders becoming disenfranchised and disengaged from governance.
+1. Equal weight -- “One Token One Vote”
+2. Limited skin in the game -- no cost to vote (price, lock ups, etc.).
 
-We propose a new governance system where voters must burn their HNT in order to vote. This system helps encourage consensus building because contentious votes are more expensive than landslides. It also imposes a significant cost on any large holder which tries to control governance, leading to less oligarchic governance outcomes.
+This approach is vulnerable to people borrowing tokens to vote. With the low voter turnout seen with governance votes in many other protocols, this attack vector is fairly easy to execute. We anticipate a higher signal in the voting process when voters have to own the consequences of their votes.
+
+“One token one vote” also commonly concentrates voting power in the hands of whales and early miners and adaptors. This can lead to smaller holders becoming disenfranchised and disengaged from governance. Large holders can also manipulate the voting process by concentrating their votes at the end of a voting period.
+
+We propose a governance implementation where voters that win the vote must**lock up their HNT** for a predetermined amount of time. Lock up time is proportional to how contentious a vote is (a 51%-49% win would require a longer lockup than a 75%-25% win). This system encourages consensus building as contentious votes become more expensive to voters than landslides. It also imposes a significant cost on any large holder who tries to control governance.
+
+We also propose having declining weight per token in the voting process to encourage timely voting and reduce last minute manipulations.
+
 
 # Stakeholders
 [stakeholders]: #stakeholders
@@ -31,87 +39,79 @@ All Helium Network stakeholders are affected by this HIP.
 # Detailed Explanation
 [detailed-explanation]: #detailed-explanation
 
-Anyone can bring a chain var update to a vote by posting a bond of 1% of staked HNT. This will create 2 burn addresses, one to accept the HIP and one to reject it. The voting period will be 1,008 epochs (21 days). During this time anyone can send staked HNT to either address. Only staked HNT is eligible to vote.
+## Vote Initiation and Weighting
 
-At the end of the voting period the protocol determines the winner by seeing which address received the most tokens. Addresses which voted for the winner get a refund of their winning margin. For example if there were 200k votes for yes and 50k votes for no, the voters for yes would get 75% (150k) of their tokens back distributed pro rata amongst them.
+Anyone can bring a HIP to a vote by posting a bond of**100,000 HNT**. This will be a chain variable that can be adjusted by governance. This bond is necessary to protect against spam HIPs. This bond will be locked up until the end of the vote and will not be eligible to vote.
 
-Votes earlier in the process get higher weight to incentivize people to vote early rather than wait for the last minute. For the first three days of voting, each HNT will have equal voting weight (so as to not immediately provide an advantage to the proposer of the vote), but the decay in voting power begins after this point. The “decay” of vote strength should be a chain variable. The initially proposed value of this chain variable is 3.33% per day – meaning that 1 HNT deposited on the third day of voting counts as 1 HNT but if it was deposited on the fourth day of voting it counts at 0.967 HNT and the other 0.033 HNT is burned.
+Only staked HNT is eligible to vote. Votes are done through a new transaction type which will be detailed in a further revision of this HIP.
 
-![](https://lh4.googleusercontent.com/yfRQ1Id0sK3LjbWAjZ-FDVTA6-j-KorzIqbOfOkOC3KfTGbUQRARrhxQhHvNc1OwzrHVfq9-GovKRm-TBImlTnG60tRejXfZ5T3vGys0SEMzrIRjFnG3X93YEEbGIZeD8oSwM3E)  
+We recommend a 7 day period between HIP submission (defined as the posting of the bond) and the start of the voting process. This waiting period prevents HIP authors from having an undue advantage on the voting process considering the decaying voting strength introduced in the next paragraph. After the waiting period, the voting process lasts for 21 days (1008 epochs).
+
+In this proposal, HNT corresponds to a certain number of “vote credits”. Network participants who participate earlier in the process get a higher weight in order to disincentivize adversarial last minute shifts in balance. For the first 7 days of voting (14 days since proposal submission), each HNT will have equal voting weight, but the voting power decays linearly after that. The “decay” of vote strength should be a chain variable. The initially proposed value of this chain variable is 3.3333% per day – meaning that 1 HNT deposited until the seventh day since the voting starts counts as 1 vote credit but if it is deposited at the last second of the voting process on the 21st day, it has only 0.3 vote credits.
+
+![](https://lh4.googleusercontent.com/PuwNiLI82brcIcWHTJNMMhVx3aNV6wmQ1g43Akd19Wr1ykRifYmrSOi6LXbnMnNwFeU2iSTLMsC1kqfNLxc0OOudrMvioJY7WXC81JUMJ9Wh3hDupfywW_5b36_OZKL6t3aI_28)
+
+
+## Lockup Amount and Mechanism
+
+At the end of the voting epoch, suppose the vote credits are distributed as x% for the losing address and (100 - x)% for the winning address.
+
+There is no lock up if votes are passed with greater than or equal to 80% majority (x&lt;=20%). If x>20%, we define the lockup period for the HNT contained in the winning address as per the following formula (in days):
   
-However, the current implementation still does not address the issue of having an asymmetric cost ascribed to expressing preferences as in the voting process. There is no incentive to vote without some increased certainty that one’s vote is “pivotal” to the outcome, since voting is strictly negative EV in payoff terms assuming there is nonzero participation throughout the vote. Coalitions are difficult for low token holders to participate in, given the risk of losing their holdings and not having the vote land in their favour. As a solution, HNT submitted for voting ‘for’ or ‘against’ a specific proposal will be sent to state channels such that the contract only deposits the HNT to the respective address if a minimum is hit (i.e. total HNT ‘against’ would be 1.5x votes ‘for’ before some time t_n &lt; T where T is the end of the voting period, and n is the is the current day or epoch prior to that point)
+![](https://lh5.googleusercontent.com/cljWpx5-WOPvC8fLKV3pNpvMOgX5jTsokMfJX94ePDZihjjw3Tgzr3qBqfp1wmBqjZLj37hhv8Rpw9SWHWmDYvhdi_wpz2UyUCVM4x1trH2U-ad5-68x8UN_IhIw8ttwM__Yjxo)  
 
-![](https://lh6.googleusercontent.com/YBrpA3YrUAyG_apxOi3D1EjVr3GALdKPEuABAVuYjko9fohciEmvjDMhFWypUcGe3jHuBoaD5bYItfrvlazQ8NJB1YZh0xDJkfjxwpa0ap464kL3I8xHnWEv_a_HOjeE-X15Ye8)  
-  
-For any vote in the opposite direction of the current winning side, EV increases if there is a significant winning margin after one’s vote is cast. If ‘against’ votes are ever roughly equal to ‘for’ votes, then both sides burn their balances without adding a significant edge since it is trivial for one side to marginally vote more in the next move. There will be some specific incremental amount that acts as a kind of dominated strategy, based on prior data around voting that can be input to the mixed strategy equation. In the diagram below we have considered a minimum 100% margin i.e. the cost to shift the vote is always 100% more than the last staked amount.
+The shape of the curve is as follows:
 
-The state channel should not be capped at any amount prior to deposit, since EV for voting against the winning direction increases with a significant winning margin not only in outcome terms (deciding the outcome of the actual vote), but also payoff terms (the higher the winning margin, the higher the portion of staked HNT is returned to the voter)
+![](https://lh6.googleusercontent.com/WQ9Rpir-AE-zinmrDrZT5Nx066RwhCx2RwS-XpSO_ebr1rzz5uuz9Nu43CPKlCrnAFbBzIZehNmBXOEDuVxLX3I3FL1ggJRr9PF4Ic74ZtLJMb2cMbm2W67ADRVVdvmk5BAWu7k)
 
-The initial bond amount must be fixed, such that no high balance HNT holder can create a vote with a very high ‘amount to beat’, and the cost of putting a contentious proposal to vote is the same for each participant in the network.
+The intention is that the lockup period increases exponentially with the contentiousness of the vote. This should encourage consensus building off-chain because contentious votes impose a large liquidity cost. If a vote still ends up being contentious, we believe that it must be an extremely important parameter that the community cares about and hence winners should bear the consequences of their choices.
 
-The benefits of this proposal are:
+Note: The lockup period imposed by governance is incremental to the unbonding period for validators.
 
-- Expensive to vote so you only vote if you really care
-- Having a contentious vote is extremely expensive so it is worth building consensus on a proposal so others don’t block you
-- Voting creates deflationary pressure on HNT supply for all network participants
-- Further increases incentives for staking HNT
-- Naturally decentralizes over time. Right now there are only a handful of people who care enough about the system to burn a bunch of money to have a voice in governance. As the system gets more important to more stakeholders, more people will care enough to vote despite the cost
-- State channels minimize expected loss of participation by turning this voting exercise into a mixed strategy game with linear payoffs, and also prevent outcomes where an outcome is decided without a significant margin of victory i.e. no side can win by submitting 1 HNT more than the other side
-- Much less oligarchic than 1 token 1 vote like tezos or compound. 1 token 1 vote which just means early whales control governance forever. In governance by burn, if whales try to control governance against others they start losing tokens and stop being whales.
+
+**Validator Rewards and Consensus**
+
+Tokens locked due to governance continue to accrue validator rewards and those rewards are not subject to lock-up.
+
+Tokens locked due to governance can vote on future HIPs; future victories add to the lock-up period.
+
+
+## List of Chain Variables
+
+We need to decide which are the exact chain variables we are governed by this system. The authors intend to work with the community and the core developers to build this list.
+
+[Attached](https://helium.plus/chain-vars)
+
+
+# Benefits
+[benefits]: #benefits
+
+1. Consequences to voting, so less risk of low conviction votes
+2. Having a contentious vote is extremely expensive, so it is worth building consensus on a proposal prior to voting.
+3. Locking via vote creates scarcity on the circulating market supply of HNT for all network participants.
+4. Much less oligarchic than one token one vote, partially preventing whales from de facto control of governance proposals. In governance by lock, whales who try to control contentious governance decisions start locking up tokens and bearing the cost.
+
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-1. Participants necessarily lose tokens to express preferences in the network
-2. Contentious votes are very expensive to propose and participate in
-    - For someone to vote against a proposal, their expectation of the event in which the proposal passes must be less than cost of voting, and they must have conviction that their votes will drive the proposal in their favour
-    - Cost of voting decreases with margin of victory. Addresses with high balances have lower marginal utility for each incremental HNT held, so voting remains less costly
-3. We assume all voters prioritize winning the proposal over their HNT staked in voting. This may limit the development of the protocol as minor changes may be contentious, and therefore expensive and unlikely to be proposed.
-4. It is difficult to calculate the payoff for participation in any given vote.
+1. It is difficult to calculate the lockup time for participation in any given vote. The uncertainty might lower voter participation.
+
 
 # Rationale
 [rationale]: #rationale
 
-1. Weighted voting attaches a tax toward proposing and participating in protocol changes, and this tax increases in how contentious the specific proposal is
-2. The token burn simultaneously adds deflationary pressure to HNT, distributing the tax paid by proposal participants to the broader community
-3. Time-weighted votes allow for fairer markets in that they disincentivize last minute bids
-4. State channels allow for less wasteful coalition formation, allowing all network participants to be pivotal to a given vote, and not just high balance HNT holders
+1. Weighted voting attaches a cost to proposing and participating in contentious protocol changes, forcing the winners of the vote to be locked into the system and bear the consequences of their decision.
+2. The token lock means only long term network participants will vote on network direction.
+3. Allowing staked tokens to vote aligns incentives with holders who believe in a project. Decred is one of the long standing examples of this system.
+4. Time-weighted votes allow for fairer markets that disincentivize last minute swings in votes.
 
-# Alternatives
-[alternatives]: #alternatives
 
-1. Shape of bonding curve for time-weighted vote
-    - Quadratic Decay: 1 - kT^2
-    - ![quadratic decay](https://lh5.googleusercontent.com/LnJ4oI9bXq-3YXeTr092HEKn64c9fgzrAwrpVgIyjkDdDmttllHqSV-t1yRxJCAwdhWRuAeb_Jkw0TPC2nmJrhDX_HgyO7SjViOQnMqLpDXRkE9I-VqKbcPMYD7ier9A0x06Ltc)  
-  
-2. Log Decay: max(1, 1 - log(kT))
-    - Considerations: Ideally, the curve should be flat for a very small portion of the initial stage, as any dropoff after the vote is proposed immediately disadvantages the opposition
+# Open Questions For The Community
+[openquestions]: #openquestions
 
-3. Burn/Return amounts (P are votes in wining address, Q are votes in losing address)
-    1. Linear (current)
-        1. Burn: 2Q
-        2. Return: P - Q pro rata ownership
-    2. Dollar Auction
-        1. Burn: Q
-        2. Return: P pro rata ownership
-        - Each side is incentivized to outbid the other, may be too destructive
-
-4. Quadratic or Linear Coefficient (alternatives to state channels)
-    1. Burn: 2(sqrt Q) or 2/n \* Q (n is number of unique addresses participating)
-    2. Return: P - sqrt Q and Q - sqrt Q, P - (2/n)\*Q and Q - (2/n)\*Q
-        - Makes votes slightly less expensive to participate in, and increases the payoff for voting against proposals
-
-5. What are the conditions for proposing a vote
-    1. Minimum bond amount
-        1. 1% of staked HNT may be too high
-    2. Minimum engagement on HIP forums
-        1. Should there be a threshold amount of prior discussion before a vote is proposed, as this ensures clear discussion of the ramifications of approving or rejecting the change
-6. What can we assume about voters
-    1. What percentage of balance can we expect rational voters to dedicate toward voting? How should this inform the minimum bond amount?
-7. Alternatives to burning/minting
-    1. Curve-like vote locking (voting escrow, less price impact on contentious votes)
-
-# Deployment Impact
-[deployment-impact]: #deployment-impact
-
-TBD
+1. Should we have a maximum cap for lockup across votes?
+   - One idea from the authors is to have a max cap on the lock-up period of 2 years across all votes. How likely is it that someone wants to break the network after locking a meaningful amount of tokens for 2 years? The total lack of a cap could discourage high signal participation because of personal liquidity profiles. The function could also be modified such that it would require several contentious votes to reach the proposed cap.
+2. Should bond amount be a function of chain variables? What specific set of variables, if they are changed, would pose an existential threat to the network?
+3. Should we have governance boosters for holders who stake for long periods of time? E.g. - sqrt (n\*t) boosters?
+4. Should we grant core devs with veto rights (as a failsafe) as we kickstart this process?

--- a/0031-governance-by-token-lock.md
+++ b/0031-governance-by-token-lock.md
@@ -1,12 +1,13 @@
 # HIP 31: Governance by Token Lock
 
-- Authors: Tushar Jain, Shayon Sengupta
+- Authors: [Tushar Jain](https://github.com/@tjmcc), Shayon Sengupta
 - Start Date: November 14, 2020
 - Category: Governance
-- Original PR: TBD
-- Tracking Issue: TBD
+- Original HIP PR: https://github.com/helium/HIP/pull/182
+- Tracking Issue: https://github.com/helium/HIP/issues/183
+- Status: In Discussion
 
-## Summary
+# Summary
 [summary]: #summary
 
 This proposal suggests on-chain governance voting for implementations of chain variables and protocol upgrades.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you have questions or feedback, please ask in [#hip-open-discussion in the co
 | 28 | [Consensus Reward Adjustments](https://github.com/helium/HIP/blob/master/0028-consensus-reward-adjustments.md) | [In Discussion](https://github.com/helium/HIP/issues/140) |
 | 29 | [Multi-signature Keys](https://github.com/helium/HIP/blob/master/0029-multisignature-keys.md) | [Approved](https://github.com/helium/HIP/issues/157) |
 | 30 | [BLS12-381 for Threshold Cryptography](https://github.com/helium/HIP/blob/master/0030-update-threshold-cryptography.md) | [Approved](https://github.com/helium/HIP/issues/158) |
-| 31 | [Governance by Token Burn](https://github.com/helium/HIP/blob/master/0031-governance-by-token-burn.md) | [In Discussion](https://github.com/helium/HIP/issues/183) |
+| 31 | [Governance by Token Lock](https://github.com/helium/HIP/blob/master/0031-governance-by-token-lock.md) | [In Discussion](https://github.com/helium/HIP/issues/183) |
 | 32 | [Split DCs Among All Transferers](https://github.com/helium/HIP/blob/master/0032-split-dcs.md) | [In Discussion](https://github.com/helium/HIP/issues/221) |
 | 33 | [Regional Reward Adjustments](https://github.com/helium/HIP/blob/master/0033-regional-reward-adjustments.md) | [In Discussion](https://github.com/helium/HIP/issues/222) |
 | 34 | [Validator Node Security](https://github.com/helium/HIP/blob/master/0034-validator-node-security.md) | [In Discussion](https://github.com/helium/HIP/issues/223) |


### PR DESCRIPTION
A rewrite of the existing HIP31. This proposal suggests on-chain governance voting for implementations of chain variables and protocol upgrades.