### PR TITLE
Mark HIP28 as approved

### DIFF
--- a/0028-consensus-reward-adjustments.md
+++ b/0028-consensus-reward-adjustments.md
@@ -6,7 +6,7 @@
 - Original HIP PR: https://github.com/helium/HIP/pull/136
 - Tracking Issue: https://github.com/helium/HIP/issues/140
 - Code PR: https://github.com/helium/blockchain-core/pull/922
-- Status: In Discussion
+- Status: [Approved](https://github.com/helium/HIP/issues/140#issuecomment-892848351)
 
 # Summary
 [summary]: #summary

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you have questions or feedback, please ask in [#hip-open-discussion in the co
 | 25 | [Validators](https://github.com/helium/HIP/blob/master/0025-validators.md) | [Approved](https://github.com/helium/HIP/issues/111) |
 | 26 | [Payment Notes](https://github.com/helium/HIP/blob/master/0026-payment-notes.md) | [In Discussion](https://github.com/helium/HIP/issues/125) |
 | 27 | [Support CBRS 5G](https://github.com/helium/HIP/blob/master/0027-cbrs-5g-support.md) | [Approved](https://github.com/helium/HIP/pull/133) |
-| 28 | [Consensus Reward Adjustments](https://github.com/helium/HIP/blob/master/0028-consensus-reward-adjustments.md) | [In Discussion](https://github.com/helium/HIP/issues/140) |
+| 28 | [Consensus Reward Adjustments](https://github.com/helium/HIP/blob/master/0028-consensus-reward-adjustments.md) | [Approved](https://github.com/helium/HIP/issues/140) |
 | 29 | [Multi-signature Keys](https://github.com/helium/HIP/blob/master/0029-multisignature-keys.md) | [Approved](https://github.com/helium/HIP/issues/157) |
 | 30 | [BLS12-381 for Threshold Cryptography](https://github.com/helium/HIP/blob/master/0030-update-threshold-cryptography.md) | [Approved](https://github.com/helium/HIP/issues/158) |
 | 31 | [Governance by Token Lock](https://github.com/helium/HIP/blob/master/0031-governance-by-token-lock.md) | [In Discussion](https://github.com/helium/HIP/issues/183) |


### PR DESCRIPTION
On behalf of the DeWi and broader Helium community, I'm happy to label this HIP as "community approved." 

This comes in recognition of:
- wide support from the community on multiple [community calls](https://dewi.org/community-calls)
- nearly unanimous support in Discord straw polling (though emoji data was lost to some Discord server gremlins)
- support (in principle) from members of the core development team

HIP author @PaulVMo has also written the first draft of actual code because he is awesome! That PR is [helium/blockchain-core#922](https://github.com/helium/blockchain-core/pull/922) and is undergoing review by the core development team. Please follow that issue for updates; when it is merged or rejected I'll try to update here.

Please note that community approval of a HIP and the development, review and deployment of live, functioning code are two distinct processes, and the core devs drive on the latter.
