### PR TITLE
Update HIP19 to link to new repository

### DIFF
--- a/0019-third-party-manufacturers.md
+++ b/0019-third-party-manufacturers.md
@@ -132,11 +132,11 @@ Both Helium and RAK hotspots are (presumably) running the same miner software as
 
 ## How To Apply
 
-Interested manufacturers should:
+Interested manufacturers should visit the [dewi-alliance/hotspot-manufacturers](https://github.com/dewi-alliance/hotspot-manufacturers/) repository, which contains instructions on how to submit an application and tracking issues for in-progress applications.
 
-* Make a copy of the [TEMPLATE.md](./0019-third-party-manufacturers/TEMPLATE.md) file in this repository and put it in the same directory, i.e. `0019-third-party-manufacturers/name-of-your-company.md`
+* Make a copy of the `TEMPLATE.md` file
 * Fill it out; if you have questions or concerns about a particular question, just leave it blank and ask on GitHub or on Discord.
-* Submit a pull request
+* Submit a GitHub pull request
 * Discussion and approval would follow the same "rough consensus” process used by HIPs generally, as outlined in [HIP7](https://github.com/helium/HIP/blob/master/0007-managing-hip-process.md).
 
 Sensitive information like financials or proofs of identity could be furnished to members of both Helium Inc. and the Decentralized Wireless Alliance (DeWi) and attested publicly, via the HIP document, GitHub comments, or otherwise.


### PR DESCRIPTION
Tried to preserve original language but point people to the new repository, which is the most up-to-date.