### PR TITLE
clarify 6-month lockup for validator rollover

### DIFF
--- a/0076-linear-lockup-curve.md
+++ b/0076-linear-lockup-curve.md
@@ -139,7 +139,7 @@ veHNT under all circumstances.**
 
 Therefore, we propose to remove the special-case provision of HIP-51 that a 6-month lockup receives
 a 1x veHNT multiplier. Instead, it will receive the same veHNT as implied by the linear decay
-function, which is approximately 12.5x.
+function, which is 12.5x. e.g, a 100 HNT stake for 6 months will establish a 1250 veHNT position at the time of staking.
 
 We also propose that the 6-month minimum lockup period be removed and HNT holders be allowed to lock
 HNT for any desired period up to 48 months, including periods less than 6 months.

--- a/0076-linear-lockup-curve.md
+++ b/0076-linear-lockup-curve.md
@@ -139,7 +139,8 @@ veHNT under all circumstances.**
 
 Therefore, we propose to remove the special-case provision of HIP-51 that a 6-month lockup receives
 a 1x veHNT multiplier. Instead, it will receive the same veHNT as implied by the linear decay
-function, which is 12.5x. e.g, a 100 HNT stake for 6 months will establish a 1250 veHNT position at the time of staking.
+function, which is 12.5x. E.g, a 100 HNT stake for 6 months will establish a 1250 veHNT position at
+the time of staking.
 
 We also propose that the 6-month minimum lockup period be removed and HNT holders be allowed to lock
 HNT for any desired period up to 48 months, including periods less than 6 months.

--- a/0076-linear-lockup-curve.md
+++ b/0076-linear-lockup-curve.md
@@ -35,7 +35,7 @@ durations.
 
 We propose eliminating the 6-month minimum lockup period, allowing participants to lock for any
 desired period up to the maximum, including shorter periods with an accordingly smaller associated
-amount of veHNT.
+amount of veHNT. Validator stakes that roll over into locked HNT will still be locked for 6 months.
 
 **3. Introduce 1 HNT minimum lockup**
 
@@ -138,11 +138,16 @@ incentive to lock HNT, if a position of HNT locked for 6 months had the same ass
 veHNT under all circumstances.**
 
 Therefore, we propose to remove the special-case provision of HIP-51 that a 6-month lockup receives
-a 1x veHNT multiplier. Instead, it will receive the same implied by the linear decay function, which
-is approximately 12.5x.
+a 1x veHNT multiplier. Instead, it will receive the same veHNT as implied by the linear decay
+function, which is approximately 12.5x.
 
 We also propose that the 6-month minimum lockup period be removed and HNT holders be allowed to lock
-HNT for any desired period, including periods less than 6 months.
+HNT for any desired period up to 48 months, including periods less than 6 months.
+
+This change will not apply to validator stakes that have not completed cooldown at transition. In
+recognition of the fact that validator stakers have already made decisions based on the 6-month
+lockup proposed in HIP-70, an automatic 6-month lockup will apply to all validator stakes that roll
+over into locked HNT at transition as described in HIP-70.
 
 The implementation calculates veHNT with a granularity of 1 day. The maximum lockup duration,
 specified in HIP-51 as 48 months, corresponds to 1461 days.
@@ -158,21 +163,20 @@ multiplier.
 
 ![veHNT curve HIP](https://user-images.githubusercontent.com/1608050/214618746-33cecad9-3de0-4e7c-a420-799347c476a2.png)
 
-The 6-month lockup period specified in HIP-51 for validator stakes that have not completed cooldown
-at L1 transition will continue to apply. Still, the associated validator HNT accounts will receive
-approximately 12.5x veHNT, or 125,000 veHNT per 10,000 HNT validator stake, instead of 10,000 veHNT
+Given this function, a 10,000 HNT validator stake that has not completed cooldown when the Solana L1
+transition occurs will receive approximately 12.5x veHNT, or 125,000 veHNT, instead of 10,000 veHNT
 as specified in HIP-51.
 
 These 125,000 veHNT per validator will be subject to the 3x multiplier for staking in the initial
-7-day landrush period after the Solana L1 transition. Thus the total veHNT issued to validator
-accounts will be 375,000. This will revert back to 125,000 at the end of the 6-month 3x multiplier
-bonus period unless the lockup period is extended within the landrush period.
+7-day landrush period. Thus the total veHNT issued per validator stake will be 375,000. This will
+revert back to 125,000 at the end of the 6-month 3x multiplier bonus period, unless the lockup
+duration is extended within the landrush period.
 
 Equally, any HNT holder may lock HNT for 6 months and receive 12.5x veHNT instead of 1x veHNT as
 specified in HIP-51, with an additional 3x multiplier if locked within the initial 7-day landrush
 period.
 
-The veHNT allocation for a 48-month lockup remains unchanged at 100x veHNT or 300x with landrush
+The veHNT allocation for a 48-month lockup remains unchanged at 100x veHNT, or 300x with landrush
 multiplier if applicable.
 
 The behavior of the 3x landrush multiplier is unchanged from HIP-51. To clarify, the 3x multiplier
@@ -273,7 +277,7 @@ and reduce the cost of changes should they become necessary in the future.
 The 6-month minimum lockup period for legacy validator stakes that have not completed cooldown at
 transition is unaffected. Validator stakes that transition to locked HNT will be assigned the same
 6-month lockup period, but will benefit from a 12.5x veHNT multiplier instead of the 1x multiplier
-specified in HIP-51.
+specified in HIP-70.
 
 Other participants will be able to lock HNT for any period without a 6-month minimum. The veHNT
 multipliers for short lock durations will be significantly higher than those specified by HIP-51.


### PR DESCRIPTION
HIP-70 specifies the duration of the automatic lockup period applied to an HNT validator stake that has not completed cooldown at transition, and is therefore rolled over into a locked HNT position, as the “minimum lockup period”, which is defined in HIP-51 as 6 months. This HIP revises the minimum lockup period to zero. Thus we now clarify that the validator rollover lockup period is still 6 months.

#560