### PR TITLE
comment out prose wrap and print width in prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
-  "printWidth": 100,
-  "proseWrap": "always",
+  // "printWidth": 100,
+  // "proseWrap": "always",
   "semi": false,
   "trailingComma": "all",
   "singleQuote": true,


### PR DESCRIPTION
no more forced wraps! (if using vscode and prettier)