### PR TITLE
Update 0082-helium-mobile-service-provider.md

### DIFF
--- a/0082-helium-mobile-service-provider.md
+++ b/0082-helium-mobile-service-provider.md
@@ -21,7 +21,7 @@ As a Service Provider member of the Helium Mobile subDAO, Helium Mobile will act
 
 This HIP affects:
 
-- Subscribers interested in using a crypto-carrier for cellular services - will benefit by having inexpensive, private cellular Service and get rewards from Helium Mobile for improving the Network.
+- Subscribers interested in using a crypto-carrier for cellular services - will benefit by having inexpensive, private cellular Service and being enabled to get rewards for improving the Network.
 - Mobile carrier partners of Helium Mobile - will have an economic opportunity to increase revenue by sharing their mobile infrastructure.
 - Owners of Hotspots with active Radios - will be rewarded for providing data access to Subscribers.
 - Helium Mobile - will have an opportunity to provide cellular Service to Subscribers and earn rewards.


### PR DESCRIPTION
Changing a potentially incorrect phrasing. The incorrect phrasing introduces a contradiction to HIP 79:

HIP 79 says SPs aren't able to redistribute Mobile rewards to subscribers (for legal reasons)

The original phrasing here in HIP 82 can be easily read as "HM pays subscribers Mobile tokens that HM temporarily owned" - thus contradicting the statement in HIP 79 that SPs can't do that.

But what actually happens (in my understanding is): Having a subscription is a prerequisite to do discovery mapping and to get MOBILE rewards out of the mapper rewards bucket. Thus HM does not pay rewards, but being a subscriber of HM only enables discovery mapping and getting rewards for discovery mapping. 

The suggested change to the HIP reflects this.