### PR TITLE
Create 0000-Preventing Rug Pull, Conflicts of Interest, and Centraliz…

### DIFF
--- a/0000-Preventing Rug Pull, Conflicts of Interest, and Centralization
+++ b/0000-Preventing Rug Pull, Conflicts of Interest, and Centralization
@@ -1,0 +1,127 @@
+# HIP
+
+0000-Preventing Rug Pull, Conflicts of Interest, and Centralization
+
+- Author(s): @rf1re
+- Start Date: 1/1/2024
+- Category: meta
+- Original HIP PR: <!-- leave this empty; maintainer will fill in ID of this pull request -->
+- Tracking Issue: <!-- leave this empty; maintainer will create a discussion issue -->
+
+## Summary
+
+This proposal is to ban, prevent, or otherwise discard HIP proposals written by Nova Labs employees, as they have conflicting interest by putting the profits of a private company above the community members who build out the network.  This also proposes that employees of Nova Labs have their wallets made public, and barred from participating in voting on HIPs.
+
+## Motivation
+
+HIP101 written by a Nova employee proposes changes to the network that would start a cycle of transition away from CBRS by redistributing rewards away from the community members who invested in building out the CBRS network.  As stated in the HIP, the effect would be a long term reduction in rewards to CBRS.  What it doesn’t state is that the primary effect of that HIP would be a long term increase in profits for Nova Labs by pivoting to a technology that would earn Nova Labs more at the expense of the CBRS community.  This also disincentivizes the community from finding a fix for the CBRS issue they claimed was the reason for the HIP.  The conflict arises when Nova Labs employees can propose changes that undermine the investments of the community to the profit of their own company.
+
+Having a Nova (formerly Helium Inc) employee proposing changes to the network also skirts the line of direct involvement for the Howey test, putting added risk on the actual decentralization of the network as it appears to be run by proxy which may garner SEC attention and lawsuits.  Nova Labs employees should be barred from voting as well for this same reason.
+
+Ensuring Network Integrity and Decentralization: By restricting Nova Labs employees from proposing changes to the network, this proposal supports the use case of maintaining a truly decentralized network. This is crucial for the network's integrity, as it prevents any single entity from exerting undue influence or control over the network's evolution.
+
+Protecting Community Investments: Many community members have invested significant resources in building out the CBRS network. This proposal supports the use case of safeguarding these investments by preventing proposals that could undermine the value of these community-driven efforts, ensuring that their contributions remain valuable and relevant.
+
+Promoting Fair Governance: The proposal advocates for transparent and equitable governance within the Helium network. By making Nova Labs employees' wallets public and barring them from voting on HIPs, it supports the use case of fair and transparent decision-making processes, where conflicts of interest are minimized.
+
+Encouraging Community-Led Solutions: This proposal also supports the use case of encouraging and empowering the community to actively participate in problem-solving. By preventing Nova Labs employees from steering the network's direction, it opens up opportunities for community members to propose and implement solutions, fostering a more collaborative and innovative environment.
+
+Regulatory Compliance and Risk Mitigation: The proposal supports the crucial use case of maintaining regulatory compliance, particularly concerning decentralization standards that may be scrutinized by entities like the SEC. By minimizing direct involvement from Nova Labs, the proposal aims to uphold the decentralized nature of the network, thereby reducing the risk of regulatory challenges.
+
+This Helium Improvement Proposal (HIP) addresses a critical problem of potential conflicts of interest within the Helium network's governance. By proposing a ban on Nova Labs employees from submitting HIPs and participating in voting, the HIP seeks to prevent scenarios where the private interests of a corporate entity could override the collective interests of the Helium community. This is particularly important in decisions that affect network rewards distribution and technology choices, ensuring that such decisions are made impartially and in the best interest of the network's health and growth, rather than being influenced by the profit motives of a single company.
+
+Additionally, the proposal aims to mitigate regulatory risks associated with the decentralization criteria of cryptocurrencies. By reducing the direct involvement of Nova Labs in network decision-making, the HIP addresses concerns that might arise from regulatory bodies like the SEC, which could perceive excessive corporate influence as a sign of centralization. This is crucial for maintaining the network's credibility as a decentralized system and for protecting it from potential legal and regulatory challenges that could arise from perceptions of centralization and corporate control.
+
+Implementing this proposal is expected to significantly enhance the governance integrity of the Helium network by removing conflicts of interest. By restricting Nova Labs employees from submitting or voting on HIPs, it aims to protect the community's investments and ensure decisions align with the network's decentralized ethos. This approach is anticipated to strengthen the network's regulatory standing and foster greater community trust and participation.
+
+## Stakeholders
+
+Stakeholders for this HIP are the entire network, including CBRS owners, token holders, Nova Labs, businesses, exchanges, and all other related parties.
+
+They will have the opportunity to address their views on Discord.
+
+## Detailed Explanation
+
+This proposal introduces a new governance framework within the Helium network, primarily focused on preventing conflicts of interest. It establishes a clear rule: employees of Nova Labs are prohibited from submitting Helium Improvement Proposals (HIPs) and from participating in the voting process on any HIP. This is to ensure that decisions made within the network are free from corporate bias and align with the decentralized ethos of Helium.
+
+Implementation of the Proposal:
+
+The Helium Foundation will be instrumental in defining and establishing the protocols for identifying Nova Labs employees and their associated wallet addresses. This will involve close cooperation to ensure accurate and privacy-compliant identification.
+
+They can also aid in the development or adaptation of tools required to enforce the new rules. This includes modifications to the HIP submission and voting processes to automatically detect and exclude proposals from Nova Labs employees and to prevent their participation in the voting process.
+
+The Helium Foundation, with its broader oversight role, can be tasked with monitoring compliance with these rules. It would involve periodic audits and reviews to ensure that the governance changes are being adhered to effectively.  HIPs written in violation of these rules will be reverted.
+
+The Foundation can facilitate communication and feedback channels with the broader Helium community. This will help in gathering input on the implementation process and addressing any concerns that arise during the transition.
+
+The implementation will involve several steps:
+
+Identification and public disclosure of Nova Labs employees' wallet addresses to ensure transparency.
+Modification of the HIP submission and voting processes to automatically exclude proposals from identified Nova Labs employees and prevent these wallets from participating in votes.
+Establishment of a monitoring and enforcement mechanism to ensure ongoing compliance with these rules.
+
+Representative Examples:
+
+For instance, if a Nova Labs employee proposes a HIP that favors a technology shift benefiting Nova Labs financially, under this new rule, such a proposal would be automatically disqualified. This protects the network from decisions that could prioritize corporate profits over community welfare.
+
+A potential corner case might be a Nova Labs employee indirectly influencing HIPs through third parties. To mitigate this, any proposal with a suspected indirect link to Nova Labs employees should be subject to additional scrutiny. This could include a deeper investigation into the origins of the proposal and the relationships between the proposer and any Nova Labs employees.
+
+## Drawbacks
+
+Implementing this proposal could create tension between Nova Labs and the community.  (Though this may already be present with HIP101 among others.)  Enforcing these restrictions could raise privacy concerns and add complexity to governance processes.
+
+## Rationale and Alternatives
+
+This proposal is designed to address potential conflicts of interest and ensure the integrity of the Helium network's governance. It is grounded in the principle of decentralization, a core value of the Helium network. By prohibiting Nova Labs employees from submitting or voting on HIPs, the proposal aims to maintain a level playing field for all network participants and safeguard the network from influences that could compromise its decentralized nature. This approach is vital for preserving the network's credibility, particularly in regulatory aspects, and for fostering trust within the community.
+
+Considered Alternatives:
+
+Limited Restrictions: An alternative considered was imposing less stringent restrictions, such as allowing Nova Labs employees to submit HIPs but not vote on them. However, this was deemed insufficient to address the potential for significant influence over the network's direction.
+
+Full Transparency Without Restrictions: Another option was to require full transparency of Nova Labs employees' involvement without imposing any restrictions. While transparency is beneficial, this approach does not adequately address the risk of conflict of interest.
+
+Third-Party Oversight: Involving an independent third party to oversee proposals and voting by Nova Labs employees was also considered. However, this could introduce additional complexity and potential biases, undermining the self-governing ethos of the network.
+
+Impact of Not Implementing This Proposal:
+
+Not implementing this proposal could lead to continued concerns about the influence of corporate interests on the Helium network, potentially eroding trust among community members. It could also increase the risk of regulatory scrutiny if the network is perceived as not being sufficiently decentralized. This situation could hinder the network's growth and innovation by discouraging community participation and investment.
+
+## Unresolved Questions
+
+One key aspect to be resolved during the HIP process is the precise definition of 'involvement' of Nova Labs employees. This includes determining the extent to which these employees can engage in discussions or provide insights without directly influencing the decision-making process.
+
+Another area that needs further discussion is striking the right balance between the privacy of Nova Labs employees and the transparency requirements of the proposal. This involves resolving how much information about these employees should be public and the methods used to ensure privacy compliance.
+
+The details of monitoring and enforcement mechanisms need to be refined during the implementation phase. This includes establishing clear guidelines and tools for identifying Nova Labs employees and ensuring compliance with the new rules.
+
+The process of engaging with the community to gather feedback and ensure widespread understanding and support for the proposal will be an ongoing aspect of its implementation.
+
+While this proposal addresses a specific aspect of governance related to Nova Labs employees, broader governance reforms within the Helium network are out of its scope. These issues may need to be addressed in future HIPs.
+
+The impact of this proposal on long-term incentive structures for network participation and growth is an important topic but falls outside the immediate scope of this HIP.
+
+The success of this proposal depends significantly on the collaboration with the Helium Foundation. Clear milestones need to be established for the Foundation's involvement in implementing the proposal.
+
+Achieving community consensus is a critical dependency. Specific milestones in terms of community engagement and feedback collection should be set and met to ensure the proposal is aligned with the community's interests.
+
+## Deployment Impact
+
+The implementation of this proposal will have a minimal direct impact on the day-to-day operations of most Helium network users. The primary group affected will be Nova Labs employees, who will no longer be able to submit or vote on HIPs. For the broader community, the change represents an enhancement in the governance model, reinforcing the network's decentralized ethos. Users invested in the network's governance and future development may experience a shift in the proposal landscape, with a possible increase in community-led initiatives.
+
+Upon approval and implementation of this proposal, it will be necessary to update the Helium documentation, specifically sections pertaining to the HIP process. This will include:
+
+Adding guidelines about the restrictions on Nova Labs employees regarding HIP submission and voting.
+Updating the governance section to reflect the new processes and rules.
+Providing FAQs or explanatory content to clarify the reasons and implications of these changes for the community.
+The Helium Foundation and community contributors will play a key role in ensuring that documentation is updated promptly and accurately.
+
+This proposal does not directly impact the technical infrastructure of the Helium network and is thus backward compatible. It focuses on governance processes rather than on network protocols. However, should the need arise to revert this decision, it would require a new HIP to be proposed and passed through the standard governance process. This would involve community discussion and consensus, ensuring that any decision to revert is made with the same level of consideration as the original proposal.
+
+Since this proposal does not affect the technical aspects of the network, a traditional migration procedure is not applicable. The primary transition will be in the governance process, requiring awareness campaigns and updates to the documentation to ensure that all community members are informed about the new rules.
+
+## Success Metrics
+
+Governance Participation Metrics: A key indicator of success will be an increase in the diversity and number of community members participating in the HIP process. This can be measured by tracking the number of unique proposal submissions and votes from a broader range of network participants, indicating a more inclusive and decentralized governance process.
+Community Feedback and Sentiment Analysis: Regular surveys and sentiment analysis within the community channels can be used to gauge the community's acceptance and perception of the new governance model. Positive feedback and active engagement in discussions related to governance changes would indicate successful acceptance.
+Regulatory Compliance Monitoring: Keeping track of any regulatory inquiries or actions related to the network's decentralization status will be crucial. A reduction in regulatory concerns or inquiries can be seen as a success metric for this proposal, as it aims to solidify the network's standing as a decentralized entity.
+Transparency and Compliance Reports: The generation of regular transparency reports detailing compliance with the new governance rules, especially concerning Nova Labs employees' involvement, will be essential. These reports should show adherence to the new rules, thereby proving a reduction in potential conflicts of interest.


### PR DESCRIPTION
HIP101 written by a Nova employee proposes changes to the network that would start a cycle of transition away from CBRS by redistributing rewards away from the community members who invested in building out the CBRS network.  As stated in the HIP, the effect would be a long term reduction in rewards to CBRS.  What it doesn’t state is that the primary effect of that HIP would be a long term increase in profits for Nova Labs by pivoting to a technology that would earn Nova Labs more at the expense of the CBRS community.  This also disincentivizes the community from finding a fix for the CBRS issue they claimed was the reason for the HIP.  The conflict arises when Nova Labs employees can propose changes that undermine the investments of the community to the profit of their own company.

Proposals for network changes made by Nova Labs (previously known as Helium Inc) employees can give an impression of indirect centralization, potentially jeopardizing the network's decentralized status. This perceived proxy control over network decisions could attract the scrutiny of regulatory bodies such as the SEC, raising concerns about the network's compliance with decentralization standards. Therefore, to mitigate this risk and maintain the integrity of the network's decentralized nature, it is proposed that Nova Labs employees be excluded from the voting process on these matters.

By restricting Nova Labs employees from proposing changes to the network, this proposal supports the use case of maintaining a truly decentralized network. This is crucial for the network's integrity, as it prevents any single entity from exerting undue influence or control over the network's evolution.

Many community members have invested significant resources in building out the CBRS network. This proposal supports the use case of safeguarding these investments by preventing proposals that could undermine the value of these community-driven efforts, ensuring that their contributions remain valuable and relevant.

The proposal advocates for transparent and equitable governance within the Helium network. By making Nova Labs employees' wallets public and barring them from voting on HIPs, it supports the use case of fair and transparent decision-making processes, where conflicts of interest are minimized.

This proposal also supports the use case of encouraging and empowering the community to actively participate in problem-solving. By preventing Nova Labs employees from steering the network's direction, it opens up opportunities for community members to propose and implement solutions, fostering a more collaborative and innovative environment.

The proposal supports the crucial use case of maintaining regulatory compliance, particularly concerning decentralization standards that may be scrutinized by entities like the SEC. By minimizing direct involvement from Nova Labs, the proposal aims to uphold the decentralized nature of the network, thereby reducing the risk of regulatory challenges.