### PR TITLE
HIP 123: Updates

### DIFF
--- a/0123-redefining-data-only-onboarding-and-assertion-fees.md
+++ b/0123-redefining-data-only-onboarding-and-assertion-fees.md
@@ -1,6 +1,6 @@
 # HIP 123: Redefining IOT Data-Only Hotspot Onboarding and Assertion Fees
 
-- Authors: [@Ducktatorrr](https://github.com/Ducktatorrr) and Members of the IoT Working Group
+- Authors: [@Ducktatorrr](https://github.com/Ducktatorrr), Members of the IoT Working Group
 - Start Date: 2024-05-13
 - Category: Economic, Technical
 - Original HIP PR: [#1006](https://github.com/helium/HIP/pull/1006)
@@ -11,78 +11,71 @@
 
 ## Summary
 
-This proposal aims to reduce the cost of onboarding data-only hotspots to the Helium network and to provide one free location assertion every 30 epochs. This initiative is designed to lower the barriers to entry for deploying low-cost IoT solutions using off-the-shelf LoRaWAN gateways and enhance the network's coverage and data accuracy through more frequent location updates.
+This proposal aims to reduce the cost of onboarding [data-only Hotspots](https://docs.helium.com/iot/data-only-hotspots) to the Helium IOT Network. This initiative is designed to lower the barriers to entry for deploying low-cost IoT solutions using off-the-shelf LoRaWAN gateways and enhance the network's coverage and data accuracy through more accessible onboarding and location updates.
 
 ## Motivation
 
-- **Why are we doing this?**
-    - To make onboarding for data-only hotspots more affordable and offer one free location assertion monthly to enhance network data quality and accessibility.
-- **What use cases does it support?**
-    - This facilitates easier and more economical IOT network coverage expansion, particularly benefiting asset tracking applications that rely on trilateration and precise network mapping.
-- **What problems does it solve?**
-    - It lowers the financial and technical hurdles for sensor deployers and network users, encouraging broader participation and engagement.
-- **What is the expected outcome?**
-    - Increased adoption of Helium's IOT network through lower initial costs and incentivized location assertions, leading to denser and more accurate network coverage.
+The class of Hotspot known as a "Data-only Hotspot" enables the carte blanche onboarding of any LoRaWAN gateway to the Helium IOT Network. This ability is a valuable tool for IoT companies looking to migrate fleets Helium or expand coverage leveraging readily available hardware. As a tradeoff, these Hotspots do not participate in Proof of Coverage and are eligible to earn IOT tokens only for the work of transferring LoRaWAN traffic.
 
-  In general the IoT Working Group believes that by adopting this proposal, Helium can enhance its IOT network's robustness and utility while fostering a more vibrant and inclusive community of developers and users.
+An off-the-shelf LoRaWAN gateway is capable of transferring traffic through the Helium Network when paired with [gateway-rs](https://github.com/helium/gateway-rs), the light client which enables communication with the Helium Packet Router for PoC-enabled and data-only Hotspots alike. This software package can be used without any onboard or assert of the Hotspot. Increasing functionality is illustrated in the table below:
 
+| Gateway State                        | Ability                                                                    |
+| ------------------------------------ | -------------------------------------------------------------------------- |
+| gateway-rs installed and configured. | Data transfer is allowed, but not rewarded to any entity.                  |
+| Hotspot is onboarded.                | Data transfer is rewarded to the Hotspot.                                  |
+| Hotspot location is asserted.        | Hotspot location is known to the network and returned in payload metadata. |
+
+Status quo pricing for the onboarding of a data-only Hotspot is defined as:
+
+| Action                                            | Cost               |
+| ------------------------------------------------- | ------------------ |
+| Data-Only Onboard                                 | 1,000,000 DC ($10) |
+| Location Assert (incl elevation and Antenna gain) | 500,000 DC ($5)    |
+| Transaction Fee                                   | ~0.1 Sol           |
+
+This HIP recognizes that incentive of data transfer rewards and location metadata may be insufficient to encourage data-only Hotspot operators to fully onboard their hardware. As a result, the Helium Network loses out on valuable data. On-chain knowledge of the Hotspot location enables its inclusion on maps, enabling the broader Helium community to depend on on this coverage for their own sensor deployments. Additionally, precise location of a Hotspot offers benefit asset tracking applications that rely on multilateration.
+
+During the time of writing, 1883 unonboarded and unasserted Hotspots were observed to be transferring data on the network. This HIP aims to enable these and future operators to onboard and assert their Hotspots without concern for the financial burden. The IoT Working Group believes that by adopting this proposal, Helium can enhance the IOT Network's robustness and utility while fostering a more vibrant and inclusive community of developers and users.
 
 ## Stakeholders
 
-- **Who is affected by this HIP?**
-    - Existing and future operators of data-only hotspots will benefit from reduced costs and the ability to update their data-only hotspots' locations without additional charges once per month.
-    - Developers of Helium Wallets or Maker Apps that allow location assertion
-    - Developers of Helium CLI and API tools that allow location assertion
-
+Existing and future operators of data-only Hotspots will benefit from reduced costs or the ability to update their data-only Hotspot's location for a lower fee.
 
 ## Detailed Explanation
 
-- **Introduce and explain new concepts:**
-    - This HIP will reduce the cost of onboarding data-only hotspots from 1,000,000 DC ($10) to 500,000 DC ($5). After successful onboarding, each data-only hotspot will automatically receive one free location assertion every 30 epochs, requiring no Data Credits (DC). This initial assertion per period is free. Should further assertions be desired within the same period, they will be charged at 100,000 DC ($1) each.
-
-- **How the proposal would be implemented:**
-    - Users will use the Helium Wallet App, Maker App, or CLI Wallet to initiate location assertions. The system will check if a free assertion is available; if not, a fee will apply. The onboarding process remains unchanged but at a reduced cost. Solana fees will still apply for both onboarding and assertions.
-
+This HIP will reduce the cost of onboarding a data-only Hotspot from 1,000,000 DC ($10) to 50,000 DC ($0.50).  
+The cost of a location assertion will be reduced from 500,000 DC ($5) to 50,000 DC ($0.50).
 
 ## Drawbacks
 
-- **Primary drawbacks:**
-    - The main concern is the potential reduction in DC burn per onboarding or assertion. However, the increase in the number of data-only hotspots and assertions might compensate for this reduction by enhancing network coverage and utility.
-
-  A theoretical drawback might arise if vendors do not update their Maker Apps timely, potentially causing issues with onboarding or incorrect fee applications. However, this risk is mitigated by the proactive involvement of Seeed, the primary data-only hotspot vendor, who is likely to update their applications promptly. Coordination with all related vendors to ensure timely updates will be crucial in avoiding this potential pitfall.
-
+The main concern is the potential reduction in DC burn per onboarding or assertion. However, the increase in the number of data-only hotspots and assertions might compensate for this reduction by enhancing network coverage and utility.
 
 ## Rationale and Alternatives
 
-- **Why is this design the best?**
-    - It significantly lowers the entry barrier, allowing existing LoRaWAN deployers and IoT enthusiasts easier access to the network, potentially increasing overall network engagement and data validity.
-- **What other designs have been considered?**
-    - Alternatives included varying fee structures and assertion frequencies, but the current proposal optimally balances cost reduction with network growth.
-- **What is the impact of not doing this?**
-    - Without implementing these changes, growth in network coverage and the integration of new technologies might stagnate, reducing the network's effectiveness and competitive edge.
+This HIP significantly lowers the entry barrier for onboarding and assertion, allowing existing LoRaWAN deployers and IoT enthusiasts easier access to the network, potentially increasing overall network engagement and data validity.
 
+The price effectively discourages spamming of location assertion while balancing a de minimis cost for operators to overcome when onboarding their Hotspots.
+
+Other approaches have been considered in the discussion of this HIP:
+- $5 onboard with free location assert every 30 epoch ($1 location assertion if within the 30 epoch period)
+- Free onboard and assertion of data-only Hotspots
+
+If this HIP or another of similar design is not approved, data-only Hotspots may continue to brought online without the inclusion of their on-chain onboarding and assert.
 
 ## Unresolved Questions
 
-- **Questions to resolve during the HIP process:**
-    - Final determination of the exact onboarding and assertion fees and the duration of the free assertion period will be crucial.
-
+None.
 
 ## Deployment Impact
 
-- **Impact on current users:**
-    - Users will gain the ability to update data-only hotspot locations monthly without a fee, encouraging more active and accurate participation in network data reporting.
-- **Changes to documentation:**
-    - The Helium documentation will need updates to reflect new fee structures and the benefits of the free monthly location assertion.
-- **Responsibility and blockchain involvement**
-    - The implementation of this proposal requires some changes to blockchain operations, which will need to be undertaken by the Helium Foundation or Nova or another willing party (T.B.D.)
+The Helium documentation will need updates to reflect new fee structures and the benefits of the free monthly location assertion. Pages of particular focus:
+- https://docs.helium.com/iot/data-only-hotspots
+- https://docs.helium.com/tokens/data-credit#iot-protocol-fees
 
-  Additionally, all developers of Helium Wallets, Maker Apps, CLI, and API tools must update their software to accommodate the new fee structure and free assertion feature to ensure smooth operation across the network.
-- **Backwards compatibility:**
-    - This proposal is designed for easy reversibility, minimizing disruptions in the event that we need to revert to previous settings. Should a rollback be necessary, developers of Helium Wallet, Maker Apps, CLI, and API tools will need to re-implement the original fee structures and assertion rules. This requirement ensures the changes are manageable but would involve coordinated efforts across all developer platforms to maintain assertion and onboarding functionality for data-only hotspot opperators.
+Additionally, all developers of Helium Wallets, Maker Apps, CLI, and API tools must update their software to accommodate the new fee structure and free assertion feature to ensure smooth operation across the network.
 
+This proposal is designed for easy reversibility, minimizing disruptions in the event that we need to revert to previous settings. Should a rollback be necessary, developers of Helium CLI will need to re-implement the original fee structures and assertion rules. This requirement ensures the changes are manageable but would involve coordinated efforts across all developer platforms to maintain assertion and onboarding functionality for data-only hotspot operators.
 
 ## Success Metrics
 
-- **Metrics for success:**
-    - A successful outcome will be measured by an increase in the number of active data-only hotspots.
+A successful outcome will be measured by an increase in the number of active data-only Hotspots.

--- a/0123-redefining-data-only-onboarding-and-assertion-fees.md
+++ b/0123-redefining-data-only-onboarding-and-assertion-fees.md
@@ -15,7 +15,7 @@ This proposal aims to reduce the cost of onboarding [data-only Hotspots](https:/
 
 ## Motivation
 
-The class of Hotspot known as a "Data-only Hotspot" enables the carte blanche onboarding of any LoRaWAN gateway to the Helium IOT Network. This ability is a valuable tool for IoT companies looking to migrate fleets Helium or expand coverage leveraging readily available hardware. As a tradeoff, these Hotspots do not participate in Proof of Coverage and are eligible to earn IOT tokens only for the work of transferring LoRaWAN traffic.
+The class of Hotspot known as a "Data-only Hotspot" enables the carte blanche onboarding of any LoRaWAN gateway to the Helium IOT Network. This ability is a valuable tool for IoT companies looking to migrate fleets to Helium or expand coverage leveraging readily available hardware. As a tradeoff, these Hotspots do not participate in Proof of Coverage and are eligible to earn IOT tokens only for the work of transferring LoRaWAN traffic.
 
 An off-the-shelf LoRaWAN gateway is capable of transferring traffic through the Helium Network when paired with [gateway-rs](https://github.com/helium/gateway-rs), the light client which enables communication with the Helium Packet Router for PoC-enabled and data-only Hotspots alike. This software package can be used without any onboard or assert of the Hotspot. Increasing functionality is illustrated in the table below:
 
@@ -30,10 +30,10 @@ Status quo pricing for the onboarding of a data-only Hotspot is defined as:
 | Action                                            | Cost               |
 | ------------------------------------------------- | ------------------ |
 | Data-Only Onboard                                 | 1,000,000 DC ($10) |
-| Location Assert (incl elevation and Antenna gain) | 500,000 DC ($5)    |
+| Location Assert (incl elevation and antenna gain) | 500,000 DC ($5)    |
 | Transaction Fee                                   | ~0.1 Sol           |
 
-This HIP recognizes that incentive of data transfer rewards and location metadata may be insufficient to encourage data-only Hotspot operators to fully onboard their hardware. As a result, the Helium Network loses out on valuable data. On-chain knowledge of the Hotspot location enables its inclusion on maps, enabling the broader Helium community to depend on on this coverage for their own sensor deployments. Additionally, precise location of a Hotspot offers benefit asset tracking applications that rely on multilateration.
+This HIP acknowledges that data transfer rewards and location metadata might not provide enough incentive for data-only Hotspot operators to fully onboard their hardware. Consequently, the Helium Network misses out on valuable data. On-chain knowledge of a Hotspot's location allows it to be included on maps, which the broader Helium community can rely on for their sensor deployments. Furthermore, the precise location of a Hotspot is advantageous for asset tracking applications that rely on multilateration.
 
 During the time of writing, 1883 unonboarded and unasserted Hotspots were observed to be transferring data on the network. This HIP aims to enable these and future operators to onboard and assert their Hotspots without concern for the financial burden. The IoT Working Group believes that by adopting this proposal, Helium can enhance the IOT Network's robustness and utility while fostering a more vibrant and inclusive community of developers and users.
 
@@ -44,11 +44,12 @@ Existing and future operators of data-only Hotspots will benefit from reduced co
 ## Detailed Explanation
 
 This HIP will reduce the cost of onboarding a data-only Hotspot from 1,000,000 DC ($10) to 50,000 DC ($0.50).  
-The cost of a location assertion will be reduced from 500,000 DC ($5) to 50,000 DC ($0.50).
+The cost of a location assertion will be reduced from 500,000 DC ($5) to 50,000 DC ($0.50).  
+SOL fees remain unaffected.
 
 ## Drawbacks
 
-The main concern is the potential reduction in DC burn per onboarding or assertion. However, the increase in the number of data-only hotspots and assertions might compensate for this reduction by enhancing network coverage and utility.
+The main concern is the potential reduction in DC burn per onboarding or assertion. However, the increase in the number of data-only Hotspots and assertions might compensate for this reduction by enhancing network coverage and utility.
 
 ## Rationale and Alternatives
 
@@ -57,6 +58,7 @@ This HIP significantly lowers the entry barrier for onboarding and assertion, al
 The price effectively discourages spamming of location assertion while balancing a de minimis cost for operators to overcome when onboarding their Hotspots.
 
 Other approaches have been considered in the discussion of this HIP:
+
 - $5 onboard with free location assert every 30 epoch ($1 location assertion if within the 30 epoch period)
 - Free onboard and assertion of data-only Hotspots
 
@@ -69,12 +71,13 @@ None.
 ## Deployment Impact
 
 The Helium documentation will need updates to reflect new fee structures and the benefits of the free monthly location assertion. Pages of particular focus:
+
 - https://docs.helium.com/iot/data-only-hotspots
 - https://docs.helium.com/tokens/data-credit#iot-protocol-fees
 
 Additionally, all developers of Helium Wallets, Maker Apps, CLI, and API tools must update their software to accommodate the new fee structure and free assertion feature to ensure smooth operation across the network.
 
-This proposal is designed for easy reversibility, minimizing disruptions in the event that we need to revert to previous settings. Should a rollback be necessary, developers of Helium CLI will need to re-implement the original fee structures and assertion rules. This requirement ensures the changes are manageable but would involve coordinated efforts across all developer platforms to maintain assertion and onboarding functionality for data-only hotspot operators.
+This proposal is designed for easy reversibility, minimizing disruptions in the event that we need to revert to previous settings. Should a rollback be necessary, developers of Helium CLI will need to re-implement the original fee structures and assertion rules. This requirement ensures the changes are manageable but would involve coordinated efforts across all developer platforms to maintain assertion and onboarding functionality for data-only Hotspot operators.
 
 ## Success Metrics
 

--- a/0123-redefining-data-only-onboarding-and-assertion-fees.md
+++ b/0123-redefining-data-only-onboarding-and-assertion-fees.md
@@ -43,9 +43,7 @@ Existing and future operators of data-only Hotspots will benefit from reduced co
 
 ## Detailed Explanation
 
-This HIP will reduce the cost of onboarding a data-only Hotspot from 1,000,000 DC ($10) to 50,000 DC ($0.50).  
-The cost of a location assertion will be reduced from 500,000 DC ($5) to 50,000 DC ($0.50).  
-SOL fees remain unaffected.
+This HIP will reduce the cost of onboarding a data-only Hotspot from 1,000,000 DC ($10) to 50,000 DC ($0.50). The cost of a data-only Hotspot's location assertion will be reduced from 500,000 DC ($5) to 50,000 DC ($0.50). SOL fees remain unaffected.
 
 ## Drawbacks
 


### PR DESCRIPTION
- Elaborates on motivation and background
- Sets onboarding and assertion costs to $0.50 and $0.50, respectively
- Eliminates the 30-epoch threshold for free onboarding

For approval by @Ducktatorrr and the broader IoT Working Group