### PR TITLE
HIP 122: Updates

### DIFF
--- a/0122-amend-service-provider-hex-boosting.md
+++ b/0122-amend-service-provider-hex-boosting.md
@@ -11,15 +11,16 @@
 
 ## Summary
 
-This HIP aims to do three (3) things to amend HIP-84 Service Provider Hex Boosting.
-1. Create a dedicated Service Provider Hex Boosting Rewards bucket. This will be 10% within the entire ecosystem. This will be taken out of the current 20% PoC bucket, making the regular PoC bucket 10% of the ecosystem after. The 40% data bucket that bleeds into PoC if unused will remain untouched.
-2. Reduce the minimum time for Service Provider Hex Boosting to 3 months.
-3. Limit FUTURE boost creation to a maximum of 10x.
+This HIP aims to do three (3) things to amend HIP-84 Service Provider Hex Boosting:
 
-HIP-84 Service Provider Hex Boosting, provides too much unilateral control over where rewards are distributed to any service provider at the expense of the network PoC distribution pool with no limits.
-If a service provider decides to hex boost all of Miami, the rewards distributed on behalf of the network is disproportionate to the amount burned and will disincentivize the remaining nationwide deployments on the network for the sole purpose of that service provider, ultimately dictating where the majority of rewards should go.
-While this author understands that the first service provider on the network is key to the network's success for future service providers to join, it should not be at the detriment of the network's natural expansion nationwide into other cities, and internationally. 
-Boosted Hexes rewards should be a minor part of the tokenomics distribution. With this in mind, part of this amendment also benefits the service provider in regards to HIP-84. 
+1. Create a dedicated Service Provider Hex Boosting emissions category. This will be 10% of all future emissions in the MOBILE network and will be taken out of the current Proof-of-Coverage category (reduced from 20% to 10%).
+2. Reduce the minimum time for Service Provider Hex Boosting to 3 months.
+3. Limit future boost creation to a maximum of 10x.
+
+[HIP-84](./0084-service-provider-hex-boosting.md) established Service Provider Hex Boosting but it provides too much unilateral control over emissions distribution to any Service Provider as it has no limits over the network's PoC emissions. For example, when a service provider decides to place boosts, this directs the disproportionate amount of PoC emissions, including all the Data Transfer overage, to boosted hexes. Because of this skewed emission targeting, deployments in remaining regions nationwide have a disincentive to build on the Helium MOBILE network.
+
+It's important to note that these changes do not affect the Data Transfer category of emissions where unused emissions are granted to the Proof-of-Coverage category. This mechanism will remain untouched.
+
 
 ## Prior / Related HIPs
 
@@ -41,14 +42,15 @@ This HIP is being proposed to address some concerns about the original implement
 
 This HIP aims to do three (3) things to amend HIP-84 Service Provider Hex Boosting.
 
-1. Create a dedicated Service Provider Hex Boosting Rewards bucket. This bucket will be 10% of the entire emissions of the ecosystem per epoch. This will be taken out of the current 20% PoC bucket, making the regular PoC bucket 10% of the ecosystem after. 
-    - Any excess of the 10% boosted bucket that is not used, gets distributed back to the regular PoC bucket. Similar to the data bucket. 
-    - Because of this 10% limit for the newly created Hex Boosting Bucket, this would enable a dynamic maximum / ceiling for hex boosts depending on the number of hexes that are actively pulling for boosted rewards. As of writing this HIP, the allocation of PoC to boosted hexes is far above 10%.
-    - The Helium Planner has always stated "Up to ##x"; so this precedent has already been set that none of the boosted hexes multipliers have been guaranteed that exact multiplier, and it could be lower. 
-      
+1. Create a dedicated Service Provider Hex Boosting Rewards bucket. This will be 10% of all future emissions in the MOBILE network and will be taken out of the current Proof-of-Coverage category (reduced from 20% to 10%).
+    - Any amount not used in this 10% boosted bucket, gets distributed back to the regular PoC bucket. 
+    - Boosted rewards will no longer benefit from the overflow from the Data Transfer Bucket, as they will be solely dependent on their own bucket. 
+    - Because of this 10% allocated Hex Boosting Bucket, this would enable a dynamic maximum / ceiling for hex boosts depending on the number of hexes that are actively pulling for boosted rewards. As of writing this HIP, the allocation of PoC to boosted hexes is far above 10%. This will cause boosted hexes to natively get less rewards until the bucket reaches the 10% equilibrium. 
+    - The Helium Planner has always stated "Up to ##x"; so this precedent has already been set that none of the boosted hexes multipliers have been guaranteed that exact multiplier, and it could be lower. 
+      
 3. Reduce the minimum time for Service Provider Hex Boosting to 3 months.
    - Currently set to 6 months, reducing this to 3 months allows Service Providers more flexibility in boosting a hex that they may be unsure of the actual value of that location.
-   - It also sets more precedent for deployers to not get accustomed to making contracts based on the boosted time, but rather that this is just a reward to jumpstart the deployment. 
+   - It also sets more precedent for deployers to not get accustomed to making contracts based on the boosted time, but rather that this is just a reward to jumpstart the deployment. 
       
 5. Limit FUTURE boost creation to a maximum of 10x.
    - Currently uncapped, we as a community have come to the conclusion that the 100x boosted hexes will mostly breed reward-chasing and attempted gaming of PoC.
@@ -57,7 +59,7 @@ This HIP aims to do three (3) things to amend HIP-84 Service Provider Hex Boosti
 
 ## Drawbacks
 
-In the future (when there are only up to 10x boosts), this theoretically limits the maximum amount of boosted hexes that service providers could create and be active during a range of time without hitting the maximum bucket limit. Which in turn could no longer guarantee the 10x boosts and would eventually really become 9.8x boosts, or 9.5x boosts, and so forth as more boosted hotspots get rewarded from the bucket. 
+In the future (when there are only up to 10x boosts), this theoretically limits the maximum amount of boosted hexes that service providers could create and be active during a range of time without hitting the maximum bucket limit. Which in turn could no longer guarantee the 10x boosts and would eventually really become 9.8x boosts, or 9.5x boosts, and so forth as more boosted hotspots get rewarded from the bucket. 
 
 ## Rationale and Alternatives
 
@@ -65,14 +67,13 @@ There are a few alternatives to HIP-84 that are being discussed; however, the mo
 
 ## Unresolved Questions
 
-I will add them as they come up in discussion. 
+I will add them as they come up in discussion. 
 
 ## Deployment Impact
 
-This HIP requests Nova to do the coding and implementation. This will impact the emissions allocation for boosted hexes, switching from being an almost unlimited distribution within the current PoC bucket to a bucket dedicated to boosted rewards and capped at 10% of emissions. Because of this, PoC rewards for non-boosted hexes will see an increase. 
+This HIP requests Nova to do the coding and implementation. This will impact the emissions allocation for boosted hexes, switching from being an almost unlimited distribution within the current PoC bucket to a bucket dedicated to boosted rewards and capped at 10% of emissions. Because of this, PoC rewards for non-boosted hexes will see an increase. 
 
 
 ## Success Metrics
 
-The success of this HIP will show when over-boosted areas get rewards redistributed back into the regular PoC bucket. 
-
+The success of this HIP will show when over-boosted areas get rewards redistributed back into the regular PoC bucket. 


### PR DESCRIPTION
This HIP aims to do three (3) things to amend HIP-84 Service Provider Hex Boosting:

1. Create a dedicated Service Provider Hex Boosting emissions category. This will be 10% of all future emissions in the MOBILE network and will be taken out of the current Proof-of-Coverage category (reduced from 20% to 10%).
2. Reduce the minimum time for Service Provider Hex Boosting to 3 months.
3. Limit future boost creation to a maximum of 10x.