### PR TITLE
HIP-149: track Reddit announcement post ID

### DIFF
--- a/0149-helium-utility-and-emissions-realignment.md
+++ b/0149-helium-utility-and-emissions-realignment.md
@@ -7,6 +7,7 @@ original-hip-pr: https://github.com/helium/HIP/pull/1200
 tracking-issue: https://github.com/helium/HIP/issues/1201
 vote-requirements: veHNT Holders
 status: In Discussion
+reddit-post-id: 1twsn06
 ---
 
 # HIP 149: Helium Utility and Emissions Realignment


### PR DESCRIPTION
Adds `reddit-post-id: 1twsn06` to the HIP-149 frontmatter so future status updates can comment on the existing announcement thread.

Reddit thread: https://www.reddit.com/r/HeliumNetwork/comments/1twsn06/hip149_helium_utility_and_emissions_realignment/