### PR TITLE
HIP 149: name HIP 10 and HIP 53 in the partially-amended list

### DIFF
--- a/0149-helium-utility-and-emissions-realignment.md
+++ b/0149-helium-utility-and-emissions-realignment.md
@@ -222,7 +222,9 @@ HIPs retired by Mobile PoC removal: [74][hip-74], [75][hip-75], [85][hip-85], [1
 
 HIPs retired by IoT PoC removal: [15][hip-15], [17][hip-17], [54][hip-54], [58][hip-58], [83][hip-83], [136][hip-136], [137][hip-137].
 
-HIPs retired under the SP allocation reframe: [82][hip-82] and [87][hip-87]. [HIP 93][hip-93] is partially amended.
+HIPs retired under the SP allocation reframe: [82][hip-82] and [87][hip-87].
+
+HIPs partially amended: [10][hip-10] (Mobile $/DC peg replaced by pro-rata of rewardable bytes plus the dynamic floor; IoT $/DC peg preserved), [53][hip-53] ($0.50/GB Mobile target superseded by Decision 1's dynamic floor; Mobile sub-DAO structure preserved), [93][hip-93].
 
 Documentation at <http://docs.helium.com> will need to reflect the retirement of PoC on both networks, the new Mobile allocation, and the dynamic-floor mechanism.
 
@@ -233,6 +235,7 @@ Documentation at <http://docs.helium.com> will need to reflect the retirement of
 - Operations and growth supplement vault outflows are published quarterly by the Council, with material disclosures (carrier expansion commitments, deployer programs, ecosystem grants).
 - Council activity: nominee participation, quorum on standard actions, escalation events surfaced for community vote.
 
+[hip-10]: ./0010-usage-based-data-transfer-rewards.md
 [hip-15]: ./0015-beaconing-rewards.md
 [hip-17]: ./0017-hex-density-based-transmit-reward-scaling.md
 [hip-20]: ./0020-hnt-max-supply.md


### PR DESCRIPTION
## Why

HIP 149 effectively amends HIP 10 and HIP 53 but doesn't name either in the lineage section:

- **HIP 10** (established \$/DC peg for data transfer): the Mobile peg is replaced by pro-rata of rewardable bytes plus Decision 1's dynamic floor. IoT peg is explicitly preserved (Decision 3, Stakeholders bullet). HIP 10 itself is unnamed.
- **HIP 53** (\$0.50/GB Mobile target rate): the target rate is superseded by Decision 1's dynamic floor tied to carrier-paid burn. Cited in the Motivation as background but not in the retirement list.

A careful reader sees the IoT peg explicitly preserved but Mobile's peg-retirement and the HIP 53 target's replacement are implicit. Closes that gap.

## Changes

- Move HIP 93's existing 'partially amended' note out of the SP-allocation-reframe sentence and into a dedicated 'HIPs partially amended' line
- Add HIP 10 and HIP 53 to that line with brief notes on what's preserved vs replaced
- Add HIP 10 link reference to the bibliography (HIP 53 already referenced from the Motivation)

No mechanism change. Same shape as #1205 (which trimmed the retirement list to match what HIP 149 actually retires).