### PR TITLE
HIP 149: add Advisory Council roles doc, cross-reference with Decision 4

### DIFF
--- a/0149-helium-utility-and-emissions-realignment.md
+++ b/0149-helium-utility-and-emissions-realignment.md
@@ -148,13 +148,13 @@ A 7-seat Advisory Council with standing oversight of how the operations and grow
 **Composition:**
 
 - **5 community-nominated.** Any veHNT holder above a low threshold may nominate themselves or others; each nominee confirmed by veHNT-weighted vote.
-- **2 Nova-appointed.** Designated directly by Nova; voting members; Nova responsible for their conduct.
+- **2 Nova-appointed.** Designated directly by Nova; voting members; Nova responsible for their conduct, and may replace them at any time at its discretion.
 
 **Authority:** Once seated, the Council has the following authority at any time during either supplement window.
 
 - NDA-level information rights over use of the operations and growth supplement, including insight into carrier revenue negotiations relevant to the [HIP 143][hip-143] burn-rate setting (insight only; [HIP 143][hip-143] authority stays with Nova).
-- Standard actions (demand disclosure, publish dissent, recommend course-correction): quorum 4 of 7 seated, including at least 2 community seats.
-- Trigger a community vote to terminate the supplement, or to amend its parameters (per-epoch rate, window durations, recipient vault): quorum 5 of 7 seated, including at least 3 community seats. Nova's 2 seats alone cannot trigger or block.
+- Standard actions (demand disclosure, publish dissent, recommend course-correction): 5 days' notice; quorum 4 of 7 seated, including at least 2 community seats.
+- Trigger a community vote to terminate the supplement, or to amend its parameters (per-epoch rate, window durations, recipient vault): 5 days' notice; quorum 5 of 7 seated, including at least 3 community seats. Nova's 2 seats alone cannot trigger or block.
 - No unilateral on-chain levers. Halting or amending either supplement window requires a community-voted program upgrade.
 
 **Scope.** Council authority covers the operations and growth supplement: how funds are used, and the parameters governing accrual (per-epoch rate, window durations, recipient vault). The target-minimum parameters (the 50% share and the formula) sit outside Council authority; changing them requires a community HIP and program upgrade.
@@ -167,6 +167,8 @@ A 7-seat Advisory Council with standing oversight of how the operations and grow
 - 7-day voting window.
 - Simple majority of votes cast; ≥7% quorum (symmetric with this authorizing vote: same bar to amend or terminate as to authorize).
 - 7-day enforcement: on approval, a program upgrade implementing the change is deployed within 7 days. Termination halts subsequent accrual in the active window; amendments take effect from deployment forward.
+
+**Operational terms.** The obligations a member takes on once seated, the detailed information rights, confidentiality, the HNT trading policy, and removal for cause, are set out in the [Advisory Council Roles, Responsibilities, and Access][council-roles] document and the NDA each member signs. These are operational terms; they do not alter the authority established here.
 
 ### Execution sequence
 
@@ -249,6 +251,7 @@ Documentation at <http://docs.helium.com> will need to reflect the retirement of
 - Operations and growth supplement vault outflows are published quarterly by the Council, with material disclosures (carrier expansion commitments, deployer programs, ecosystem grants).
 - Council activity: nominee participation, quorum on standard actions, escalation events surfaced for community vote.
 
+[council-roles]: ./files/0149/advisory-council-roles.md
 [hip-10]: ./0010-usage-based-data-transfer-rewards.md
 [hip-15]: ./0015-beaconing-rewards.md
 [hip-17]: ./0017-hex-density-based-transmit-reward-scaling.md

--- a/files/0149/advisory-council-roles.md
+++ b/files/0149/advisory-council-roles.md
@@ -1,0 +1,162 @@
+# HIP-149 Advisory Council: Roles, Responsibilities, and Access
+
+*Prepared by Nova Labs, Inc. for prospective Advisory Council members*
+
+## What This Document Covers
+
+This document describes what the Advisory Council does, what council members can and cannot access, the confidentiality and trading obligations that come with the seat, and how removal works. Acceptance of a council seat is contingent on signing a separate Confidentiality and Participation Agreement (the "NDA") with Nova Labs, Inc. ("Nova"), which will contain the binding terms summarized here.
+
+The council sits across two layers, with a clear division of what each owns:
+
+- **HIP 149 owns the governance rules.** It is the community-voted, on-chain instrument that creates the council and the operations and growth supplement (the "Supplement") it oversees. [HIP 149 Decision 4][hip149-d4] defines the council's composition, authority, quorums, escalation path, scope, and compensation. Those rules can only be changed by community vote and program upgrade. This document summarizes them and links to the canonical text; where the two differ, HIP 149 governs.
+- **This document and the NDA own the operational terms.** They define what a member takes on once seated: the duty of care, the specific information rights, confidentiality, the HNT trading policy, and removal for cause. These terms are set by Nova through the NDA, not through the HIP process.
+
+HIP 149 references this document for visibility and to keep the operational detail in one place. This document is not part of the HIP 149 vote and is not created or amended through a HIP. Summarizing the governance rules here rather than restating them keeps a single source of truth: a community vote that changes a Supplement parameter or the council's compensation updates HIP 149, and this document points to it.
+
+## Purpose
+
+The Advisory Council exists for one reason: oversight of the Supplement. [HIP 149 Decision 2][hip149-d2] authorizes new HNT to be minted per-epoch into a Nova-administered on-chain vault across two self-terminating windows; see that decision for the mint rate, window durations, and boundary timestamps. The council ensures the community has structured visibility into how Supplement funds are used across both windows.
+
+The council is an oversight body. It is not a board of directors, a management committee, or an executive team. Council members do not manage Nova, do not direct Nova's business operations, and do not have authority over Nova's day-to-day decisions.
+
+## Composition
+
+Canonical: [HIP 149 Decision 4][hip149-d4]. In summary:
+
+- **5 community-nominated seats**, each confirmed by veHNT-weighted vote. Any veHNT (vote-escrowed HNT) holder above the nomination threshold may self-nominate or nominate others.
+- **2 Nova-appointed seats**, designated by Nova; voting members; Nova is responsible for their conduct and may replace them at any time at its discretion.
+- **All council members' identities will be disclosed to the Helium community.** No member may serve anonymously.
+
+## Term
+
+All seven seats are co-terminus with the Supplement. Council authority begins when all seats are confirmed through the community nomination and voting process (per the [HIP 149][hip149-d4] execution sequence, approximately 7 weeks after HIP 149 passes) and ends when the Supplement's second window reaches zero and halts. There are no automatic renewals. If the community votes to terminate or amend the Supplement early, council authority adjusts accordingly.
+
+## Authority
+
+Canonical: [HIP 149 Decision 4][hip149-d4]. The council's authority is limited to oversight of the Supplement. All council actions must be exercised in connection with evaluating whether Supplement spending is consistent with HIP 149's stated purposes. The council's authority does not extend to general oversight of Nova's business, and any demand for disclosure must be reasonably related to the Supplement.
+
+**Standard actions** (5 days' notice; quorum 4 of 7 seated, including at least 2 community seats):
+
+- Demand disclosure from Nova regarding use of Supplement funds
+- Publish dissent on Nova's use of Supplement funds
+- Recommend course-correction on Supplement spending
+
+**Escalation actions** (5 days' notice; quorum 5 of 7 seated, including at least 3 community seats):
+
+- Trigger a community vote to terminate the Supplement (one or both windows)
+- Trigger a community vote to amend Supplement parameters (per-epoch rate, window durations, recipient vault)
+
+**What the council cannot do:**
+
+- Unilaterally halt, pause, or amend the Supplement on-chain
+- Direct Nova's business strategy, hiring, vendor selection, or product decisions
+- Override Nova's authority to set the carrier-paid burn rate under HIP 143
+- Bind Nova to any commitment, contract, or expenditure
+- Speak on behalf of Nova publicly, unless specifically authorized in writing
+
+Halting or amending either Supplement window requires a community-voted program upgrade. The council can trigger that vote; it cannot execute the change itself.
+
+## Duty of Care and Loyalty
+
+By accepting a council seat and signing the NDA, each member agrees to a **contractual duty of care and loyalty to the Helium Network**. This means:
+
+- **Good faith.** Act honestly and in good faith in all council activities.
+- **Reasonable diligence.** Review materials provided by Nova, attend meetings, and participate meaningfully in council deliberations.
+- **Network-first obligation.** When exercising council authority, prioritize the interests of the Helium Network as a whole over personal interests as an individual HNT holder, deployer, or business operator.
+- **No self-dealing.** Do not use the council position to obtain a personal benefit at the expense of the network or other stakeholders.
+
+This is a contractual obligation, not a fiduciary duty. It is enforceable under the NDA and is scoped exclusively to the council member role. Breach of this duty constitutes grounds for removal (see "Removal" below).
+
+## Information Access
+
+The information rights described below exist to enable the council to perform its Supplement oversight function. They are not a general right of inspection into Nova's operations, finances, or business relationships. Nova will provide information that is reasonably necessary for the council to evaluate whether Supplement funds are being used consistently with HIP 149. Requests that fall outside this standard will be declined.
+
+The full scope of the council's information rights is defined in [HIP 149 Decision 4][hip149-d4]; the standing and on-request reports below are how those rights are delivered in practice.
+
+### What the council will receive
+
+**Standing reports (quarterly):**
+
+- **Supplement outflow report.** Categorized breakdown of Supplement vault spending (e.g., carrier expansion, deployer programs, engineering, ecosystem grants, regulatory, operating costs).
+- **Summary-level financial information.** High-level revenue and cost categories sufficient to evaluate whether Supplement spending is consistent with HIP 149's stated purposes. This is summary data only; it does not include granular breakdowns.
+- **Headcount summary.** Number of roles added or reduced that are funded by the Supplement, broken down by function (e.g., engineering, carrier partnerships, deployer programs). No individual names, titles, or compensation figures.
+- **Ecosystem grant summary.** A list of grants made from the Supplement during the quarter, including the recipient, HNT amount, and stated purpose.
+- **Carrier expansion and revenue report.** Status of carrier partnerships funded in whole or in part by the Supplement: number of carriers in pipeline, signed, and live, together with the aggregate Supplement amount deployed toward carrier expansion during the quarter.
+
+**On-request reports:**
+
+- **Vendor-specific cost reports.** If a council member requests cost information about a specific vendor relationship, Nova will prepare a report if the vendor relationship has a direct impact on the Helium Network. Nova determines whether the "direct impact" standard is met.
+
+### What the council will not receive
+
+| Category | Reason |
+| ----- | ----- |
+| Granular profit-and-loss statements | Beyond the scope of Supplement oversight |
+| Tax filings or tax-related financial detail | Proprietary and not relevant to council mandate |
+| Individual employee compensation or salary data | Legally protected private information |
+| Nova's capitalization table | Proprietary corporate information unrelated to Supplement oversight |
+| Board materials, investor communications, or equity-related documents | Outside council mandate |
+| Unrestricted access to Nova's books and records | The council is not a board of directors |
+
+Being seated on the Advisory Council does not entitle a member to open-ended access to Nova's finances, operations, or corporate records. The council has structured visibility into the Supplement. That visibility is defined by this document and the NDA.
+
+## Confidentiality (NDA Summary)
+
+Every council member must sign the NDA before being seated. Key terms:
+
+- All information received through the council role is confidential unless Nova designates it as public or it becomes public through no fault of the member
+- Confidential information may not be disclosed to any third party, including other community members, deployers, or media, without Nova's prior written consent
+- Council members may discuss confidential information with each other in the course of council deliberations
+- The confidentiality obligation survives the end of the council term for a period specified in the NDA
+- Breach of confidentiality is grounds for immediate removal and may result in legal action and other available remedies
+
+The full NDA will be circulated separately. Nova is the counterparty to the NDA because Nova is the entity that holds the business information being shared with the council. The NDA governs how that information is handled. It does not alter the council's authority under HIP 149, which is established by community governance and enforceable through on-chain mechanisms independent of Nova.
+
+## HNT Trading Policy
+
+Council members may receive material non-public information ("MNPI") about Nova's operations and the Helium Network. The trading policy is designed to protect both the network and individual members from allegations of insider trading or tipping.
+
+**This is not a trading ban.** Council members may hold and trade HNT. The following safeguards apply:
+
+### Awareness obligation
+
+Members may not buy, sell, or transfer HNT (or any derivative token) while in possession of MNPI received through their council role. This is self-policed, and it is the most important rule in this section. Crucially, Nova cannot advise on whether or not any advisor is in possession of MNPI at any given time, and the advisor must make this determination for themselves on a case by case basis.
+
+### 48-hour cooling-off period
+
+No HNT trades for 48 hours following a council meeting, receipt of a quarterly report, or receipt of any other confidential information from Nova through the council channel. The clock starts when the meeting ends or the information is delivered.
+
+### Pre-notification for large trades
+
+Before executing any HNT transaction (buy or sell) with a market value exceeding $5,000, members must notify Nova in writing (email to a designated contact). This threshold is set by Nova and may be adjusted from time to time at Nova's discretion to reflect market conditions. The current threshold will be communicated to council members and included in the NDA. This is notification, not approval. Nova does not approve or deny trades. The notification creates a contemporaneous record that protects both council members and Nova.
+
+### Quarterly certification
+
+Each quarter, every council member submits a brief written attestation confirming they have not traded on MNPI received through council activities during that quarter. One sentence, one signature.
+
+### Why this matters for council members personally
+
+If a council member trades HNT based on confidential information received through the council, Nova will cooperate fully with any regulatory investigation. These safeguards exist to create a clear record that Nova maintained appropriate controls. Following them protects council members.
+
+## Compensation
+
+Canonical: [HIP 149 Decision 4][hip149-d4]. Compensation is HNT-denominated and performance-gated, paid from the Mobile and IoT Operations Funds (not from the Supplement vault). The per-seat amount is settled by community vote at first seating; see HIP 149 for the working figure.
+
+## Removal
+
+A council member may be removed for cause, as set forth in the NDA. "For cause" includes:
+
+- Fraud or dishonesty in connection with council activities
+- Violation of the duty of care and loyalty described above
+- Breach of the NDA or trading policy
+- Failure to participate in council activities over a sustained period, as specified in the NDA
+- Conduct that materially harms the Helium Network
+
+Removal procedures, including notice requirements and replacement mechanics, are set forth in the NDA. Nova reserves the right to immediately suspend a member's access to confidential information pending resolution of a for-cause determination. (Nova's authority to replace its two appointed seats at will is separate from for-cause removal; see Composition.)
+
+## Questions
+
+Prospective council members should direct questions to Nova at advisors-info@helium.com.
+
+[hip149-d2]: ../../0149-helium-utility-and-emissions-realignment.md#decision-2-operations-and-growth-supplement
+[hip149-d4]: ../../0149-helium-utility-and-emissions-realignment.md#decision-4-advisory-council


### PR DESCRIPTION
Adds the Advisory Council Roles, Responsibilities, and Access document as a supporting asset under `files/0149/` and cross-references it with HIP 149 Decision 4, so the two stop duplicating each other.

## Split

- **HIP 149 (governance layer):** composition, authority, quorums, escalation, scope, compensation, supplement parameters. Community-voted, on-chain, HIP-amendable.
- **Roles doc + NDA (operational layer):** duty of care, information-access mechanics, confidentiality, HNT trading policy, removal for cause. Set by Nova through the NDA; not part of the vote and not amended through a HIP.

Sections HIP 149 already defines are summarized in the doc and linked to the canonical text rather than restated, so a future amendment (e.g. a vote changing a supplement parameter or compensation) updates a single source. The doc is referenced for visibility only.

## Changes to HIP 149 Decision 4

- Added the 5-day notice to standard and escalation actions (previously only in the roles doc).
- Added Nova's at-will replacement of its two appointed seats to Composition (previously only in the roles doc, and de-duplicated out of the doc's Removal section).
- Added an "Operational terms" pointer and `[council-roles]` link to the new doc.

## Numbers audit

All governance-bearing numbers (seat counts, quorums, community-seat minimums, notice period, compensation, supplement parameters) live in HIP 149. The figures that remain only in the doc are conduct safeguards (48-hour cooling-off, the Nova-adjustable \$5,000 trade-notification threshold) and are intentionally kept out of the HIP.