### PR TITLE
HIP 149: add Advisory Council NDA outline as a reference document

### DIFF
--- a/0149-helium-utility-and-emissions-realignment.md
+++ b/0149-helium-utility-and-emissions-realignment.md
@@ -177,7 +177,7 @@ This is the Council's built-in escalation mechanism, not a limit on normal gover
 
 **Nova voting position.** Nova votes its veHNT like any other holder, including on votes arising from Council escalation; all votes are public on-chain. Supplement HNT is different: Nova does not lock or delegate supplement HNT for voting while it is under Nova's control. The vault address is fixed, so outflows into lockup positions are publicly traceable.
 
-**Operational terms.** The obligations a member takes on once seated, the detailed information rights, confidentiality, the HNT trading policy, and removal for cause, are set out in the [Advisory Council Roles, Responsibilities, and Access][council-roles] document and the NDA each member signs. These are operational terms; they do not alter the authority established here.
+**Operational terms.** The obligations a member takes on once seated, the detailed information rights, confidentiality, the HNT trading policy, and removal for cause, are set out in the [Advisory Council Roles, Responsibilities, and Access][council-roles] document and the [Confidentiality and Participation Agreement (NDA)][council-nda] each member signs. These are operational terms set by Nova; they are not part of this vote and do not alter the authority established here.
 
 ### Execution sequence
 
@@ -261,6 +261,7 @@ Documentation at <http://docs.helium.com> will need to reflect the retirement of
 - Council activity: nominee participation, quorum on standard actions, escalation events surfaced for community vote.
 
 [council-roles]: ./files/0149/advisory-council-roles.md
+[council-nda]: ./files/0149/advisory-council-nda.md
 [hip-10]: ./0010-usage-based-data-transfer-rewards.md
 [hip-15]: ./0015-beaconing-rewards.md
 [hip-17]: ./0017-hex-density-based-transmit-reward-scaling.md

--- a/files/0149/advisory-council-nda.md
+++ b/files/0149/advisory-council-nda.md
@@ -1,0 +1,139 @@
+# HIP-149 Advisory Council: Confidentiality and Participation Agreement (Outline of Key Terms)
+
+*Prepared by Nova Labs, Inc. for prospective HIP-149 Advisory Council members.*
+
+**Status: outline, not the final agreement.** This document summarizes the key terms of the Confidentiality and Participation Agreement (the "NDA") that each council member must sign before being seated. The final NDA will be circulated separately and may differ in wording and detail; this outline is included as an informational reference for prospective members.
+
+This document is not part of the HIP 149 vote and is not created or amended through a HIP. The NDA is a contract between Nova Labs, Inc. ("Nova") and the individual council member; its terms are set by Nova. The [Advisory Council Roles, Responsibilities, and Access memo][council-roles] is incorporated into the NDA as **Exhibit A**.
+
+## 1. Parties and Recitals
+
+This Agreement is between Nova and the individual council member identified on the signature page (the "Member").
+
+The recitals will establish the following background:
+
+- HIP 149 created the Advisory Council with oversight authority over the Supplement.
+- The Member has been nominated by the community or appointed by Nova to serve on the Council.
+- Nova will share Confidential Information so the Council can perform its oversight role.
+- This Agreement governs the Member's obligations in connection with that role.
+
+The Roles, Responsibilities, and Access memo is attached as Exhibit A and incorporated by reference into the Agreement.
+
+## 2. Definitions
+
+This section defines the key terms used throughout the Agreement. The full Agreement will include standard definitional provisions; the principal defined terms are summarized below.
+
+- **Confidential Information.** All information received through the council role, including reports described in Exhibit A, meeting materials, financial data, pricing, carrier data, vendor costs, headcount data, ecosystem grant details, and the existence and substance of council deliberations.
+- **Council, Supplement, HIP 149, and MNPI.** Carry the meanings set out in Exhibit A.
+- **Permitted Purpose.** Exercising the Member's oversight role as described in Exhibit A and HIP 149.
+
+## 3. Confidentiality Obligations
+
+This section sets out the core rules governing how the Member handles Confidential Information received through the council role.
+
+- **Use Restriction.** Confidential Information may be used only for the Permitted Purpose.
+- **Non-Disclosure.** No disclosure except to other seated Council members during deliberations, or as compelled by law.
+- **No Weaponization.** The Member may not use Confidential Information (or the fact of its existence) to disparage or bring claims against Nova, except in good-faith exercise of Council authority under HIP 149, including publishing dissent or triggering community votes.
+- **Standard of Care.** The Member must protect Confidential Information with at least the same care applied to their own confidential information, and in no event less than reasonable care.
+- **Compelled Disclosure.** If legal process requires disclosure, the Member must promptly notify Nova, cooperate with any protective-order effort, and disclose only what is strictly required.
+
+## 4. Duty of Care and Loyalty
+
+This section creates a contractual duty of care and loyalty that each Council Member owes to the Helium Network in connection with the council role.
+
+- The duty is contractual only, not a fiduciary duty. It arises from this Agreement, not from corporate law or trust law.
+- The Member must act in good faith, exercise reasonable diligence, and prioritize the interests of the Helium Network when performing council functions.
+- Self-dealing is prohibited: a Member may not use the council role to advance personal financial interests or the interests of any affiliated entity at the expense of the Network.
+- This duty is scoped exclusively to the Member's council role and terminates when the Member's seat ends (see Section 10).
+
+## 5. HNT Trading Policy
+
+This section addresses personal trading in HNT and related tokens while serving on the Council.
+
+- **Awareness Obligation.** Members may not trade HNT while in possession of MNPI received through the Council role. This obligation is self-policed; Nova cannot advise whether a Member possesses MNPI at any given time. The decision to trade, and any resulting liability, rests solely with the Member.
+- **Cooling-Off Period.** Members must observe a 48-hour cooling-off period following any Council meeting or receipt of Confidential Information before executing any HNT trade.
+- **Pre-Notification.** Trades exceeding $5,000 in market value require advance written notice to Nova. This is notification only; Nova does not approve or deny trades. Nova may adjust the $5,000 threshold at its discretion to reflect market conditions.
+- **Quarterly Certification.** Each quarter, Members must provide a brief written attestation confirming compliance with the trading policy and confirming no trades based on MNPI.
+- **Regulatory Cooperation.** Nova reserves the right to cooperate fully with any regulatory or law-enforcement investigation related to trading activity by a Council Member.
+
+## 6. Information Access and Limitations
+
+- Exhibit A (the Roles, Responsibilities, and Access memo) describes the specific categories of Confidential Information the council receives, the reporting cadence, and the format of materials provided by Nova.
+- The Member's information access is limited to the categories set out in Exhibit A. This Agreement does not grant any general right of inspection into Nova's books, records, systems, or operations beyond those categories.
+- Nova retains sole discretion over the form, level of detail, and timing of information provided, subject to the commitments described in Exhibit A and HIP 149.
+
+## 7. Member Representations
+
+Each council member will make the following representations at the time of signing:
+
+- **No Legal Restriction.** The Member is not subject to any sanctions, debarment, or pending legal proceeding that would prevent or materially conflict with service on the Advisory Council.
+- **Compliance with Law.** The Member will comply with all applicable laws in connection with council activities, including any obligations arising under the HNT Trading Policy (Section 5).
+- **Accuracy of Information.** All information the Member provided to Nova in connection with nomination or appointment is true and accurate in all material respects.
+
+## 8. Indemnification
+
+This section requires the council member to personally cover Nova's losses in certain situations, and confirms that Nova does not provide any reciprocal protection to the Member.
+
+- The Member indemnifies Nova for losses from breach of confidentiality, trading policy, or duty of care and loyalty obligations under this Agreement.
+- The Member indemnifies Nova for third-party claims caused by unauthorized disclosure of Confidential Information or trading on MNPI received through the council.
+- Nova does **not** indemnify council members. Nova has no obligation to hold harmless, defend, or indemnify any Member for any claim, liability, or expense arising from council service. Members bear their own legal risk.
+
+## 9. Limitation of Liability and Disclaimer
+
+This section addresses the limits on each party's financial exposure under the Agreement and clarifies that Nova does not guarantee the accuracy of information it provides.
+
+- Nova's total liability to the Member under this Agreement is capped at the total compensation paid to the Member during the twelve months preceding the claim. Nova is not liable for consequential, indirect, or punitive damages.
+- There is no cap on the Member's liability to Nova for breach of confidentiality or trading obligations.
+- Nova prepares reports and shares information in good faith and with reasonable care but does not warrant accuracy or completeness. Members may not rely on Confidential Information for personal investment or trading decisions.
+
+## 10. Term and Survival
+
+This section explains when the Agreement starts, when it ends, and which obligations continue after a Member leaves the council.
+
+- The Agreement is effective upon execution and remains in force for the duration of the Member's council seat. When the seat ends (for any reason), the Agreement terminates, except as noted below.
+- Confidentiality obligations survive for five years after the Member's seat ends.
+- The HNT Trading Policy awareness obligation survives until the relevant MNPI is no longer material or has become public.
+- The duty of care and loyalty terminates when the seat ends.
+- Indemnification obligations survive termination of the Agreement.
+
+## 11. Removal and Return of Information
+
+This section addresses when and how a council member may be removed, and what happens to Confidential Information when a Member's seat ends for any reason.
+
+- For-cause removal grounds: fraud, breach of duty of care or loyalty, breach of the NDA or Trading Policy, sustained non-participation, or conduct materially harmful to the Helium Network.
+- Nova may immediately suspend access to Confidential Information while a for-cause determination is pending.
+- Nova-appointed seats (2 of 7) face the same removal standards as other members, but Nova may replace its seats at its sole discretion at any time, with or without cause.
+- Upon removal or expiration of a seat, the Member must return or destroy all Confidential Information in any form and provide a written certification of destruction to Nova.
+
+## 12. Remedies
+
+This section addresses the remedies available if a Council Member breaches the Agreement, particularly obligations relating to Confidential Information or the HNT Trading Policy.
+
+- **Irreparable Harm.** The Council Member acknowledges that a breach of confidentiality or trading obligations may cause irreparable harm to Nova that cannot be adequately compensated by monetary damages alone.
+- **Injunctive Relief.** The Council Member consents to the entry of injunctive or other equitable relief in favor of Nova without the requirement of posting a bond or other security.
+- **Cumulative Remedies.** The right to seek injunctive relief does not limit any other remedies available to Nova at law or in equity, and all such remedies are cumulative.
+
+## 13. Dispute Resolution
+
+Any dispute arising under this Agreement will be resolved by binding arbitration administered by the AAA International Centre for Dispute Resolution, before a single arbitrator, seated in Wilmington, Delaware, and conducted in English.
+
+- **Injunctive Relief Carve-Out.** Either party may seek injunctive or other equitable relief in any court of competent jurisdiction to prevent breach of confidentiality or trading obligations, without waiving the right to arbitrate remaining issues.
+- **Prevailing Party Fees.** The prevailing party in any arbitration or court proceeding under this Agreement is entitled to recover reasonable attorneys' fees and costs from the other party.
+
+## 14. General Provisions
+
+This section contains the standard legal housekeeping provisions that govern how the Agreement itself operates.
+
+- **Governing Law.** Delaware law applies, without regard to conflicts-of-law principles.
+- **Entire Agreement.** This Agreement, together with Exhibit A, constitutes the complete understanding between the parties regarding its subject matter.
+- **Amendments.** Any change to the Agreement must be in writing and signed by both parties.
+- **No Assignment.** The Member may not assign or transfer this Agreement or any rights under it.
+- **Severability.** If any provision is held unenforceable, the remaining provisions continue in full effect.
+- **Counterparts and Electronic Signature.** The Agreement may be signed in counterparts, and electronic signatures are binding.
+- **Notices.** Notices under this Agreement may be delivered by email to the designated addresses specified in the signature block.
+
+## Exhibit A: HIP-149 Advisory Council Roles, Responsibilities, and Access Memo
+
+Exhibit A is the [Advisory Council Roles, Responsibilities, and Access memo][council-roles], incorporated into this Agreement by reference.
+
+[council-roles]: ./advisory-council-roles.md

--- a/files/0149/advisory-council-roles.md
+++ b/files/0149/advisory-council-roles.md
@@ -4,7 +4,7 @@
 
 ## What This Document Covers
 
-This document describes what the Advisory Council does, what council members can and cannot access, the confidentiality and trading obligations that come with the seat, and how removal works. Acceptance of a council seat is contingent on signing a separate Confidentiality and Participation Agreement (the "NDA") with Nova Labs, Inc. ("Nova"), which will contain the binding terms summarized here.
+This document describes what the Advisory Council does, what council members can and cannot access, the confidentiality and trading obligations that come with the seat, and how removal works. Acceptance of a council seat is contingent on signing a separate Confidentiality and Participation Agreement (the "NDA") with Nova Labs, Inc. ("Nova"), which will contain the binding terms summarized here. This document is incorporated into the NDA as Exhibit A; an [outline of the NDA's key terms][council-nda] is available as a reference.
 
 The council sits across two layers, with a clear division of what each owns:
 
@@ -158,5 +158,6 @@ Removal procedures, including notice requirements and replacement mechanics, are
 
 Prospective council members should direct questions to Nova at advisors-info@helium.com.
 
+[council-nda]: ./advisory-council-nda.md
 [hip149-d2]: ../../0149-helium-utility-and-emissions-realignment.md#decision-2-operations-and-growth-supplement
 [hip149-d4]: ../../0149-helium-utility-and-emissions-realignment.md#decision-4-advisory-council


### PR DESCRIPTION
Adds the Confidentiality and Participation Agreement (NDA) outline of key terms as a supporting asset under `files/0149/`, referenced from HIP 149 the same way as the roles memo. Companion to #1215.

## Status

The committed file is an **outline of key terms**, not the final agreement. The final NDA will be circulated separately and may differ in wording and detail. It is included for visibility only — it is a contract between Nova and the individual member, set by Nova, **not part of the HIP 149 vote and not amended through a HIP**.

## Document relationship

- **HIP 149** (governance, voted, on-chain) → links to both the roles memo and the NDA from Decision 4's "Operational terms" pointer.
- **Roles memo** (operational summary + access detail) → incorporated into the NDA as **Exhibit A**; links to the NDA outline.
- **NDA** (the binding contract) → Exhibit A links back to the roles memo; defers definitions and information-access detail to Exhibit A.

## Consistency

Cross-checked against the roles memo and HIP 149: the 48-hour cooling-off, the Nova-adjustable \$5,000 trade-notification threshold, the for-cause removal grounds, and Nova's at-will replacement of its two seats all line up. The NDA's 5-year confidentiality survival matches the roles memo's "period specified in the NDA" (deferred, not hardcoded).