### PR TITLE
HIP plugin: fix vote-pr.sh branch check, tags, and proposals-file formatting

### DIFF
--- a/.claude/plugins/hip/scripts/vote-pr.sh
+++ b/.claude/plugins/hip/scripts/vote-pr.sh
@@ -69,16 +69,18 @@ fi
 
 BRANCH="hip-${HIP_NUMBER}"
 
-# Map category to tags
-case "$CATEGORY" in
-  economic*)  TAGS='["Economic"]' ;;
-  technical*) TAGS='["Technical"]' ;;
-  meta*)      TAGS='["Meta"]' ;;
-  *)          TAGS='["Economic", "Technical"]' ;;
-esac
+# Map category (possibly comma-separated, e.g. "economic, technical") to tags,
+# preserving every category rather than just the first. The ${TAGS//,/, } adds a
+# space after commas to match the inline-array style in helium-proposals.json.
+TAGS=$(printf '%s' "$CATEGORY" | jq -Rc '
+  split(",")
+  | map(gsub("^\\s+|\\s+$"; "") | ascii_downcase)
+  | map({economic: "Economic", technical: "Technical", meta: "Meta"}[.])
+  | map(select(. != null))')
+TAGS=${TAGS//,/, }
 
 # Check dependencies
-for cmd in jq base64; do
+for cmd in jq base64 python3; do
   if ! command -v "$cmd" &>/dev/null; then
     echo "Error: $cmd is required but not installed." >&2
     exit 1
@@ -111,56 +113,68 @@ if [[ -z "$BASE_SHA" || "$BASE_SHA" == "null" ]]; then
   exit 1
 fi
 
-# Get the current file content and its blob SHA
-FILE_RESPONSE=$("$GH" api "repos/$REPO/contents/$FILE_PATH")
-FILE_SHA=$(echo "$FILE_RESPONSE" | jq -r '.sha')
+# Get the current file's blob SHA and its raw content. Fetch raw content
+# directly (Accept: raw) instead of base64-decoding the JSON response — BSD/macOS
+# `base64 -d` mishandles the newline-wrapped base64 the contents API returns.
+FILE_SHA=$("$GH" api "repos/$REPO/contents/$FILE_PATH" --jq '.sha')
 if [[ -z "$FILE_SHA" || "$FILE_SHA" == "null" ]]; then
   echo "Error: Could not get $FILE_PATH SHA from $REPO." >&2
   exit 1
 fi
-CURRENT_CONTENT=$(echo "$FILE_RESPONSE" | jq -r '.content' | base64 -d)
+CURRENT_CONTENT=$("$GH" api "repos/$REPO/contents/$FILE_PATH" -H "Accept: application/vnd.github.raw")
 
-# Build the new entry
-NEW_ENTRY=$(jq -n \
-  --arg name "HIP-${HIP_NUMBER}: ${TITLE}" \
-  --arg uri "$GIST_URL" \
-  --arg choice_for "For HIP-${HIP_NUMBER}" \
-  --arg choice_against "Against HIP-${HIP_NUMBER}" \
-  --argjson tags "$TAGS" \
-  '{
-    name: $name,
-    uri: $uri,
-    maxChoicesPerVoter: 1,
-    tags: $tags,
-    choices: [
-      { uri: null, name: $choice_for },
-      { uri: null, name: $choice_against }
+# Build the new entry as a text block matching the file's existing style:
+# 2-space indentation with inline `tags` and `choices`. We append it textually
+# rather than re-serializing the whole array with `jq`, because jq's pretty-printer
+# expands those inline arrays and reformats every existing entry (a ~500-line diff
+# for a one-entry change). jq is used only to JSON-escape the scalar values, and
+# to validate the result below.
+NAME_JSON=$(jq -cn --arg x "HIP-${HIP_NUMBER}: ${TITLE}" '$x')
+URI_JSON=$(jq -cn --arg x "$GIST_URL" '$x')
+FOR_JSON=$(jq -cn --arg x "For HIP-${HIP_NUMBER}" '$x')
+AGAINST_JSON=$(jq -cn --arg x "Against HIP-${HIP_NUMBER}" '$x')
+ENTRY_BLOCK="  {
+    \"name\": ${NAME_JSON},
+    \"uri\": ${URI_JSON},
+    \"maxChoicesPerVoter\": 1,
+    \"tags\": ${TAGS},
+    \"choices\": [
+      { \"uri\": null, \"name\": ${FOR_JSON} },
+      { \"uri\": null, \"name\": ${AGAINST_JSON} }
     ]
-  }')
+  }"
 
-# Append to the array
-UPDATED_CONTENT=$(echo "$CURRENT_CONTENT" | jq --argjson entry "$NEW_ENTRY" '. + [$entry]')
+# Append the entry before the array's closing ']', preserving all existing bytes
+# (and the file's trailing-newline state).
+UPDATED_CONTENT=$(CUR="$CURRENT_CONTENT" ENTRY="$ENTRY_BLOCK" python3 -c '
+import os, sys
+cur = os.environ["CUR"]
+entry = os.environ["ENTRY"]
+trailing_nl = cur.endswith("\n")
+body = cur.rstrip()
+if not body.endswith("]"):
+    raise SystemExit("helium-proposals.json does not end with a JSON array")
+body = body[:-1].rstrip()  # drop the final "]" -> body now ends at the last entry "}"
+sys.stdout.write(body + ",\n" + entry + "\n]" + ("\n" if trailing_nl else ""))
+')
 
-# Check that the entry was actually added
-ORIGINAL_COUNT=$(echo "$CURRENT_CONTENT" | jq 'length')
-UPDATED_COUNT=$(echo "$UPDATED_CONTENT" | jq 'length')
-if [[ "$UPDATED_COUNT" -le "$ORIGINAL_COUNT" ]]; then
-  echo "Error: Failed to append entry to $FILE_PATH" >&2
+# Validate the result is well-formed JSON and exactly one entry was added
+ORIGINAL_COUNT=$(printf '%s' "$CURRENT_CONTENT" | jq 'length')
+UPDATED_COUNT=$(printf '%s' "$UPDATED_CONTENT" | jq 'length')
+if [[ "$UPDATED_COUNT" -ne $((ORIGINAL_COUNT + 1)) ]]; then
+  echo "Error: Failed to append entry to $FILE_PATH (or produced invalid JSON)" >&2
   exit 1
 fi
 
 echo "Creating branch $BRANCH..."
 
-# Check if branch already exists
-BRANCH_CHECK_STATUS=$("$GH" api "repos/$REPO/git/ref/heads/$BRANCH" \
-  --include 2>/dev/null | head -1 | grep -oE '[0-9]{3}' || echo "000")
-if [[ "$BRANCH_CHECK_STATUS" == "200" ]]; then
+# Check if the branch already exists. `gh api` exits non-zero on a 404, so test
+# its exit status directly — do not pipe the response through `head`/`grep`, which
+# races with SIGPIPE under `set -o pipefail` and misreports the status as "404\n000".
+if "$GH" api "repos/$REPO/git/ref/heads/$BRANCH" >/dev/null 2>&1; then
   echo "Error: Branch $BRANCH already exists in $REPO." >&2
   echo "Delete it first if you want to retry:" >&2
   echo "  $GH api repos/$REPO/git/refs/heads/$BRANCH -X DELETE" >&2
-  exit 1
-elif [[ "$BRANCH_CHECK_STATUS" != "404" ]]; then
-  echo "Error: Could not check if branch exists (HTTP $BRANCH_CHECK_STATUS)." >&2
   exit 1
 fi
 

--- a/.claude/plugins/hip/skills/vote-open.md
+++ b/.claude/plugins/hip/skills/vote-open.md
@@ -58,6 +58,19 @@ Create a markdown document summarizing the HIP for voters. This is what voters s
 - **veMOBILE Holders**: 67% voting power — ask the user for the quorum threshold
 - **Multiple vote types**: each gets its own approval section
 
+**Quorum is an absolute veHNT number, not a percentage.** The on-chain proposal resolves against a fixed vote-weight threshold, and heliumvote works in absolute veHNT (recent network-wide votes used **100,000,000 veHNT**). If the HIP states its quorum as a percentage (e.g. "≥7% quorum"), convert it to an absolute figure at vote time:
+
+1. Fetch the current delegated veHNT (what heliumvote sums as the network total):
+
+   ```bash
+   curl -s https://helium-vote-service.web.helium.io/v1/subdao-delegations
+   # {"iot":"<raw>","mobile":"<raw>"}  — raw integers, 8 decimals
+   ```
+
+2. `total veHNT = (iot + mobile) / 1e8`, then `quorum = percentage × total`. Example: at ≈862M total veHNT, 7% ≈ 60.3M veHNT.
+
+Put the absolute figure in the summary and give it to the multisig signer to configure on-chain. If the HIP body and the summary express quorum differently (% vs absolute), reconcile them so voters see one consistent bar.
+
 **Template:**
 
 ```markdown
@@ -111,6 +124,8 @@ Use the `vote-pr.sh` script:
 ```
 
 The script fetches `helium-proposals.json`, appends the vote entry, creates a branch, commits, and opens the PR. It prints the PR URL on success.
+
+The script appends the entry **textually**, preserving the file's existing inline style (2-space indent with inline `tags`/`choices`), so the PR diff is just the one new entry. Do not "simplify" it back to `jq '. + [entry]'` — jq's pretty-printer expands the inline arrays and reformats every existing entry (a ~500-line diff). A comma-separated `--category` (e.g. `"economic, technical"`) produces multiple tags.
 
 ### 5. Update the HIP frontmatter
 


### PR DESCRIPTION
Fixes captured while opening the HIP-149 vote (helium-vote#280), where `vote-pr.sh` first aborted and then produced a whole-file reformat.

## What was broken

- **Branch-existence check aborted the run.** It piped `gh api --include` through `head | grep` to read the HTTP status; under `set -o pipefail`, `head` closing the pipe sends `gh` a SIGPIPE, so the pipeline returns non-zero and the status was misread as `404\n000` — failing with "Could not check if branch exists." Now it tests `gh api`'s exit status directly (non-zero on 404).
- **Whole-file reformat.** Appending with `jq '. + [entry]'` re-serialized `helium-proposals.json`. The file uses a custom inline style (2-space indent, but `tags`/`choices` on one line); jq's pretty-printer expands all of it, reformatting every entry (~500-line diff for a one-entry add). The entry is now appended **textually** in the file's existing style — diff is just the new entry. jq only JSON-escapes the scalar values and validates the result.
- **Dropped tags.** The category→tags map kept only the first of a comma-separated category, so `"economic, technical"` produced `["Economic"]`. It now builds the full list (`["Economic", "Technical"]`).
- **base64 fragility.** Switched to fetching the file via the raw media type instead of `jq -r .content | base64 -d` (BSD/macOS `base64 -d` mishandles the newline-wrapped base64 the contents API returns).

## Doc updates (`vote-open.md`)

- Quorum is an **absolute veHNT** figure, not a percentage. Documented how to convert a HIP's stated percentage to an absolute number via `GET /v1/subdao-delegations` on the vote service (sum `iot`+`mobile`, ÷ 1e8), with the 7% ≈ 60.3M example.
- Noted the formatting-preservation rule so the textual append isn't "simplified" back to jq.

## Testing

- `bash -n` clean.
- The new tags logic and the format-preserving append were validated offline against the live `helium-proposals.json` (34 entries, valid JSON, minimal diff).
- The same operations were exercised by hand when opening helium-vote#280.
- The live API paths (raw fetch, branch creation, PR open) were not re-run end-to-end here; they're standard `gh api` calls unchanged in shape.