### PR TITLE
HIP plugin: sign the vote-proposal commit (createCommitOnBranch)

### DIFF
--- a/.claude/plugins/hip/scripts/vote-pr.sh
+++ b/.claude/plugins/hip/scripts/vote-pr.sh
@@ -113,14 +113,9 @@ if [[ -z "$BASE_SHA" || "$BASE_SHA" == "null" ]]; then
   exit 1
 fi
 
-# Get the current file's blob SHA and its raw content. Fetch raw content
-# directly (Accept: raw) instead of base64-decoding the JSON response — BSD/macOS
-# `base64 -d` mishandles the newline-wrapped base64 the contents API returns.
-FILE_SHA=$("$GH" api "repos/$REPO/contents/$FILE_PATH" --jq '.sha')
-if [[ -z "$FILE_SHA" || "$FILE_SHA" == "null" ]]; then
-  echo "Error: Could not get $FILE_PATH SHA from $REPO." >&2
-  exit 1
-fi
+# Get the current file's raw content. Fetch raw directly (Accept: raw) instead of
+# base64-decoding the JSON response — BSD/macOS `base64 -d` mishandles the
+# newline-wrapped base64 the contents API returns.
 CURRENT_CONTENT=$("$GH" api "repos/$REPO/contents/$FILE_PATH" -H "Accept: application/vnd.github.raw")
 
 # Build the new entry as a text block matching the file's existing style:
@@ -184,16 +179,35 @@ fi
   -f "sha=$BASE_SHA" > /dev/null
 BRANCH_CREATED=true
 
-echo "Committing updated $FILE_PATH..."
+echo "Committing updated $FILE_PATH (signed)..."
 
-# Encode content
+# Commit via the GraphQL createCommitOnBranch mutation, NOT the REST contents API.
+# GitHub web-flow-signs commits made through this mutation (they show as Verified);
+# the contents API does not, and helium/helium-vote's main requires signed commits —
+# a contents-API commit leaves the PR unmergeable without an admin override.
+# expectedHeadOid is the branch tip, which equals BASE_SHA right after branch creation.
 ENCODED_CONTENT=$(printf '%s' "$UPDATED_CONTENT" | base64 | tr -d '\n')
-"$GH" api "repos/$REPO/contents/$FILE_PATH" \
-  -X PUT \
-  -f "message=Add HIP-${HIP_NUMBER} vote proposal" \
-  -f "content=$ENCODED_CONTENT" \
-  -f "sha=$FILE_SHA" \
-  -f "branch=$BRANCH" > /dev/null
+COMMIT_REQUEST=$(jq -n \
+  --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }' \
+  --arg repo "$REPO" \
+  --arg branch "$BRANCH" \
+  --arg oid "$BASE_SHA" \
+  --arg message "Add HIP-${HIP_NUMBER} vote proposal" \
+  --arg path "$FILE_PATH" \
+  --arg contents "$ENCODED_CONTENT" \
+  '{query: $query, variables: {input: {
+      branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+      expectedHeadOid: $oid,
+      message: {headline: $message},
+      fileChanges: {additions: [{path: $path, contents: $contents}]}
+  }}}')
+COMMIT_RESPONSE=$(printf '%s' "$COMMIT_REQUEST" | "$GH" api graphql --input -)
+COMMIT_OID=$(printf '%s' "$COMMIT_RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid // empty')
+if [[ -z "$COMMIT_OID" ]]; then
+  echo "Error: createCommitOnBranch did not return a commit:" >&2
+  echo "$COMMIT_RESPONSE" >&2
+  exit 1
+fi
 
 echo "Opening PR..."
 

--- a/.claude/plugins/hip/skills/vote-open.md
+++ b/.claude/plugins/hip/skills/vote-open.md
@@ -120,6 +120,8 @@ The script fetches `helium-proposals.json`, appends the vote entry, creates a br
 
 The script appends the entry **textually**, preserving the file's existing inline style (2-space indent with inline `tags`/`choices`), so the PR diff is just the one new entry. Do not "simplify" it back to `jq '. + [entry]'` — jq's pretty-printer expands the inline arrays and reformats every existing entry (a ~500-line diff). A comma-separated `--category` (e.g. `"economic, technical"`) produces multiple tags.
 
+The commit is made via the GraphQL `createCommitOnBranch` mutation, **not** the REST contents API, so GitHub web-flow-signs it (shows as Verified). `helium/helium-vote` `main` requires signed commits; a contents-API commit is unsigned and leaves the PR `BLOCKED`/unmergeable without an admin override. Don't switch it back to the contents API.
+
 **Pinned vs unpinned gist URL.** The raw gist URL with a commit hash (`/raw/<sha>/…`) is version-pinned and changes whenever you edit the gist; the unpinned form (`/raw/<file>`) always serves the latest. `vote-pr.sh` records the pinned URL in `helium-proposals.json` (frozen snapshot). If you edit the gist after opening the vote PR, re-point the entry's `uri` to the new pinned URL. For the HIP frontmatter `vote-summary-url` (step 5), prefer the **unpinned** URL so it follows edits.
 
 ### How the vote goes live on-chain (after the PR merges)


### PR DESCRIPTION
`helium/helium-vote` `main` requires signed commits. `vote-pr.sh` committed the `helium-proposals.json` entry via the REST contents API, which produces an **unsigned** commit — so the vote PR read `BLOCKED` and needed an admin override to merge (HIP-149 #280 hit exactly this).

This switches the commit step to the GraphQL **`createCommitOnBranch`** mutation, which GitHub web-flow-signs (shows as **Verified**) with no GPG key to manage on the shared `hiptron` account.

**Verified on `helium-vote` with hiptron's token** (throwaway branch, since deleted): the resulting commit returned `signature.isValid: true, state: VALID, signer: web-flow`. So future vote PRs pass the signed-commits rule and merge normally — no admin override.

Also drops the now-unused `FILE_SHA` fetch, and notes in `vote-open.md` why the commit goes through the mutation (don't revert to the contents API). The format-preserving textual append is unchanged; only the transport changes (contents PUT → `createCommitOnBranch` with the same content as `fileChanges.additions`).