### PR TITLE
HIP plugin: status/assign skills open a PR instead of pushing to protected main

### DIFF
--- a/.claude/plugins/hip/skills/assign.md
+++ b/.claude/plugins/hip/skills/assign.md
@@ -350,7 +350,7 @@ git push
 Tell the user:
 > "Can't push to this fork branch. Two options:
 > 1. Ask the author to enable 'Allow edits from maintainers' on the PR, then I'll retry the push.
-> 2. I can merge the PR as-is first, then apply these changes directly to main."
+> 2. I can merge the PR as-is first, then open a follow-up PR with the number-assignment changes (`main` is protected, so this can't be a direct push)."
 
 Wait for the user's decision before proceeding.
 

--- a/.claude/plugins/hip/skills/status.md
+++ b/.claude/plugins/hip/skills/status.md
@@ -139,19 +139,26 @@ Remove whichever of these is currently on the issue, then add the new one:
 
 If transitioning to **Deployed**, also remove `in development` if present (a HIP might have had that intermediate label added manually).
 
-### 6. Commit
+### 6. Commit and open a PR
 
-Stage the changed files (HIP `.md` file and `README.md`) and commit:
+`main` is a protected branch — direct pushes are rejected (`protected branch hook declined`). Status changes go through a PR like any other change.
 
-```
-Update HIP-{NNN} status: {new status}
-```
-
-Push to `main` (status changes are direct commits, not PRs):
+Create a branch, stage the changed files (HIP `.md` file and `README.md`), and commit:
 
 ```bash
-git push
+git checkout -b hip-{NNN}-{status-slug}
+git add {NNNN-slug}.md README.md
+git commit -m "Update HIP-{NNN} status: {new status}"
 ```
+
+Commit message body: none needed. Push the branch and open a PR against `main`:
+
+```bash
+git push -u origin hip-{NNN}-{status-slug}
+gh pr create --repo helium/HIP --base main --title "Update HIP-{NNN} status: {new status}" --body "..."
+```
+
+The PR body should state the transition (old → new status) and, for a vote outcome (Approved/Rejected), the verified on-chain tally and the proposal address. Do **not** merge on your own initiative — hand the merge decision to the user. After they approve the merge, squash-merge, restore local `main` (`git checkout main && git pull --ff-only`), and delete the branch locally and on the remote.
 
 ### 7. Report
 
@@ -159,6 +166,7 @@ Tell the user:
 - HIP-**NNN** status updated to **{new status}**
 - README badge updated
 - Tracking issue labels updated: removed `{old label}`, added `{new label}`
+- PR opened: **{PR URL}** (awaiting merge approval)
 
 ---
 
@@ -166,8 +174,11 @@ Tell the user:
 
 | Failed at | What exists | Recovery |
 |---|---|---|
-| After frontmatter update but before README | Frontmatter updated, README stale | Continue manually — update README and commit |
+| After frontmatter update but before README | Frontmatter updated, README stale | Continue manually — update README |
 | After README but before label update | Files updated, labels stale | Run the label update command manually |
-| After labels but before commit | Everything updated but not committed | Just commit and push |
+| After labels but before commit | Everything updated but not committed | Create the branch, commit, and open the PR (step 6) |
+| Commit made but push rejected | Committed on `main` locally | `main` is protected. Move the commit to a branch (`git branch <b>; git reset --hard origin/main; git checkout <b>`), push it, open the PR |
 
 Status changes are idempotent — running the same transition twice is harmless (badge and labels are already in the target state).
+
+Note: the tracking-issue label update (step 5) goes through the GitHub API, not the PR, so it lands before the PR merges. The issue briefly shows the new status label while the frontmatter/README change is still in review. That is expected; the labels reflect the confirmed outcome.


### PR DESCRIPTION
The `/hip:status` skill instructed a direct `git push` to `main`, but `main` is a protected branch and rejects direct pushes (`protected branch hook declined`). Status changes must go through a PR like every other change. Recent status commits (e.g. #1229, #1232) confirm the PR path is the real workflow.

## Changes
- `status.md` step 6: "Commit" → "Commit and open a PR" (branch, commit, `gh pr create`); notes main is protected and to hand the merge decision to the user rather than self-merging.
- `status.md` step 7: report line now includes the PR URL.
- `status.md` error-recovery table: fixed the "just commit and push" row and added the "committed on main, push rejected" recovery path.
- `status.md`: note that the tracking-issue label update lands before the PR merges (it goes through the API, not the PR).
- `assign.md` fork-PR fallback: "apply changes directly to main" → "open a follow-up PR" (same protected-branch reason).

No behavior change to the number/label mechanics; this only corrects the git flow the skills describe.