### PR TITLE
gov plugin: post-incident hardening (re-issue tool, size pre-flight, skill fixes)

### DIFF
--- a/.claude/plugins/gov/scripts/edit-entry.sh
+++ b/.claude/plugins/gov/scripts/edit-entry.sh
@@ -59,8 +59,8 @@ for cmd in jq base64 python3; do
   command -v "$cmd" &>/dev/null || { echo "Error: $cmd is required." >&2; exit 1; }
 done
 # Validate the replacements file shape up front.
-if ! jq -e 'type == "array" and length > 0 and all(has("old") and has("new"))' "$REPL" >/dev/null 2>&1; then
-  echo "Error: --replacements must be a non-empty JSON array of {old,new}" >&2; exit 1
+if ! jq -e 'type == "array" and length > 0 and all(has("old") and has("new") and (.old | type == "string") and (.new | type == "string"))' "$REPL" >/dev/null 2>&1; then
+  echo "Error: --replacements must be a non-empty JSON array of {old,new} strings" >&2; exit 1
 fi
 
 AUTH_OUTPUT=$("$GH" auth status 2>&1) || {
@@ -130,7 +130,9 @@ COMMIT_REQUEST=$(jq -n \
 COMMIT_RESPONSE=$(printf '%s' "$COMMIT_REQUEST" | "$GH" api graphql --input -)
 COMMIT_OID=$(printf '%s' "$COMMIT_RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid // empty')
 if [[ -z "$COMMIT_OID" ]]; then
-  echo "Error: createCommitOnBranch did not return a commit:" >&2; echo "$COMMIT_RESPONSE" >&2; exit 1
+  echo "Error: createCommitOnBranch did not return a commit:" >&2; echo "$COMMIT_RESPONSE" >&2
+  cleanup  # explicit exit does not fire the ERR trap; delete the orphan branch
+  exit 1
 fi
 
 echo "Opening PR..."

--- a/.claude/plugins/gov/scripts/edit-entry.sh
+++ b/.claude/plugins/gov/scripts/edit-entry.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Apply a set of exactly-once string replacements to a proposals JSON file on a
+# NEW branch off the base, then open a PR — as hiptron, via a signed commit.
+#
+# Use to correct an already-merged entry (e.g. re-issue a proposal whose choice
+# labels or uri must change) without reformatting the file: each replacement is a
+# plain string swap that must match exactly once, so formatting and every other
+# entry are preserved. Validates the result parses and the entry count is
+# unchanged, then commits via the signed GraphQL createCommitOnBranch mutation
+# (helium-vote main requires signed commits).
+#
+# Usage:
+#   edit-entry.sh --branch fix-branch --replacements repl.json \
+#     --title "Fix HIP-149 election entry" \
+#     [--reference-url URL] [--file helium-proposals.json] \
+#     [--repo helium/helium-vote] [--base main]
+#
+# --replacements: JSON array of {"old": "...", "new": "..."}; each "old" must
+#                 occur exactly once in the file.
+#
+# Requires: gh CLI, jq, base64, python3
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GH="$SCRIPT_DIR/gh-hiptron.sh"
+REPO="helium/helium-vote"
+FILE_PATH="helium-proposals.json"
+BASE="main"
+
+usage() {
+  echo "Usage: $0 --branch BRANCH --replacements JSON --title TITLE [--reference-url URL] [--file FILE] [--repo OWNER/REPO] [--base BASE]" >&2
+  exit 1
+}
+
+BRANCH="" REPL="" TITLE="" REFERENCE_URL=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch)        BRANCH="$2"; shift 2 ;;
+    --replacements)  REPL="$2"; shift 2 ;;
+    --title)         TITLE="$2"; shift 2 ;;
+    --reference-url) REFERENCE_URL="$2"; shift 2 ;;
+    --file)          FILE_PATH="$2"; shift 2 ;;
+    --repo)          REPO="$2"; shift 2 ;;
+    --base)          BASE="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+if [[ -z "$BRANCH" || -z "$REPL" || -z "$TITLE" ]]; then usage; fi
+if ! [[ "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  echo "Error: --branch has invalid characters (got: $BRANCH)" >&2; exit 1
+fi
+if [[ ! -f "$REPL" ]]; then echo "Error: --replacements file not found: $REPL" >&2; exit 1; fi
+if [[ -n "$REFERENCE_URL" ]] && ! [[ "$REFERENCE_URL" =~ ^https:// ]]; then
+  echo "Error: --reference-url must be an https URL (got: $REFERENCE_URL)" >&2; exit 1
+fi
+for cmd in jq base64 python3; do
+  command -v "$cmd" &>/dev/null || { echo "Error: $cmd is required." >&2; exit 1; }
+done
+# Validate the replacements file shape up front.
+if ! jq -e 'type == "array" and length > 0 and all(has("old") and has("new"))' "$REPL" >/dev/null 2>&1; then
+  echo "Error: --replacements must be a non-empty JSON array of {old,new}" >&2; exit 1
+fi
+
+AUTH_OUTPUT=$("$GH" auth status 2>&1) || {
+  echo "Error: hiptron GitHub auth failed:" >&2; echo "$AUTH_OUTPUT" >&2; exit 1
+}
+
+BRANCH_CREATED=false
+cleanup() {
+  if $BRANCH_CREATED; then
+    echo "Cleaning up: deleting branch $BRANCH from $REPO..." >&2
+    "$GH" api "repos/$REPO/git/refs/heads/$BRANCH" -X DELETE >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup ERR
+
+echo "Fetching $FILE_PATH from $REPO@$BASE..."
+BASE_SHA=$("$GH" api "repos/$REPO/git/ref/heads/$BASE" --jq '.object.sha')
+if [[ -z "$BASE_SHA" || "$BASE_SHA" == "null" ]]; then
+  echo "Error: base branch $BASE not found in $REPO." >&2; exit 1
+fi
+CURRENT_CONTENT=$("$GH" api "repos/$REPO/contents/$FILE_PATH?ref=$BASE" -H "Accept: application/vnd.github.raw")
+
+# Apply each replacement, requiring exactly one occurrence of each "old".
+UPDATED_CONTENT=$(CUR="$CURRENT_CONTENT" REPL_JSON="$(cat "$REPL")" python3 -c '
+import os, sys, json
+cur = os.environ["CUR"]
+repls = json.loads(os.environ["REPL_JSON"])
+for i, r in enumerate(repls):
+    old, new = r["old"], r["new"]
+    n = cur.count(old)
+    if n != 1:
+        raise SystemExit(f"replacement {i}: expected exactly 1 occurrence of {old!r}, found {n}")
+    cur = cur.replace(old, new)
+sys.stdout.write(cur)
+')
+
+# Validate: still valid JSON and the entry count is unchanged.
+ORIGINAL_COUNT=$(printf '%s' "$CURRENT_CONTENT" | jq 'length')
+UPDATED_COUNT=$(printf '%s' "$UPDATED_CONTENT" | jq 'length' 2>/dev/null || echo -1)
+if [[ "$UPDATED_COUNT" != "$ORIGINAL_COUNT" ]]; then
+  echo "Error: entry count changed ($ORIGINAL_COUNT -> $UPDATED_COUNT) or invalid JSON" >&2
+  exit 1
+fi
+NUM_REPL=$(jq 'length' "$REPL")
+echo "Applied $NUM_REPL replacement(s); $ORIGINAL_COUNT entries unchanged in count."
+
+# Guard: branch must not already exist.
+if "$GH" api "repos/$REPO/git/ref/heads/$BRANCH" >/dev/null 2>&1; then
+  echo "Error: branch $BRANCH already exists in $REPO. Delete it to retry." >&2; exit 1
+fi
+echo "Creating branch $BRANCH off $BASE..."
+"$GH" api "repos/$REPO/git/refs" -f "ref=refs/heads/$BRANCH" -f "sha=$BASE_SHA" >/dev/null
+BRANCH_CREATED=true
+
+echo "Committing (signed)..."
+ENCODED_CONTENT=$(printf '%s' "$UPDATED_CONTENT" | base64 | tr -d '\n')
+COMMIT_REQUEST=$(jq -n \
+  --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }' \
+  --arg repo "$REPO" --arg branch "$BRANCH" --arg oid "$BASE_SHA" \
+  --arg message "$TITLE" --arg path "$FILE_PATH" --arg contents "$ENCODED_CONTENT" \
+  '{query: $query, variables: {input: {
+      branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+      expectedHeadOid: $oid,
+      message: {headline: $message},
+      fileChanges: {additions: [{path: $path, contents: $contents}]}
+  }}}')
+COMMIT_RESPONSE=$(printf '%s' "$COMMIT_REQUEST" | "$GH" api graphql --input -)
+COMMIT_OID=$(printf '%s' "$COMMIT_RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid // empty')
+if [[ -z "$COMMIT_OID" ]]; then
+  echo "Error: createCommitOnBranch did not return a commit:" >&2; echo "$COMMIT_RESPONSE" >&2; exit 1
+fi
+
+echo "Opening PR..."
+PR_BODY="## Summary
+${TITLE}
+
+Applied ${NUM_REPL} exactly-once string replacement(s) to \`${FILE_PATH}\`; entry count unchanged."
+if [[ -n "$REFERENCE_URL" ]]; then
+  PR_BODY="${PR_BODY}
+
+Reference: ${REFERENCE_URL}"
+fi
+PR_URL=$("$GH" pr create --repo "$REPO" --base "$BASE" --head "$BRANCH" --title "$TITLE" --body "$PR_BODY")
+BRANCH_CREATED=false
+echo ""
+echo "Done! PR created: $PR_URL"

--- a/.claude/plugins/gov/scripts/election-pr.sh
+++ b/.claude/plugins/gov/scripts/election-pr.sh
@@ -196,6 +196,30 @@ if [[ "$NEW_CHOICES" != "$CAND_COUNT" ]]; then
 fi
 
 echo "Appended election entry: $CAND_COUNT candidates, $SEATS seats."
+
+# Pre-flight size check. All choices go into one initialize_proposal_v0 wrapped in
+# a Squads V4 vault-transaction message; the create-proposals pipeline rejects it
+# ("Failed to package instructions") above ~1100 bytes. This estimate is calibrated
+# against the real @sqds/multisig serialization (constant covers the 8 accounts,
+# discriminator, vec-length prefixes, compute-budget ixs, and batch wrapper; each
+# choice costs ~5 bytes of framing plus its name; the uri and proposal name cost
+# ~1 byte/char). It reproduces the measured sizes to the byte in the relevant range.
+NAME_LEN=${#NAME}
+GIST_LEN=${#GIST_URL}
+TAGS_CHARS=$(printf '%s' "$TAGS_JSON" | jq -r '[.[] | length] | add // 0')
+NAME_CHARS=$(jq -Rrn '[inputs | gsub("^\\s+|\\s+$"; "") | select(length > 0) | length] | add // 0' "$CANDIDATES_FILE")
+EST=$(( 708 + NAME_LEN + TAGS_CHARS + 5 * CAND_COUNT + NAME_CHARS + GIST_LEN ))
+echo "Pre-flight packaged-size estimate: ~${EST} bytes (Squads V4 limit ~1100)."
+if [[ "$EST" -gt 1100 ]]; then
+  echo "Error: estimated ~${EST} B exceeds the ~1100 B Squads V4 message limit." >&2
+  echo "The post-merge create-proposals run would fail with 'Failed to package instructions'." >&2
+  echo "Shorten the ballot: plain candidate names (no @handles) and a short gist filename." >&2
+  exit 1
+elif [[ "$EST" -gt 1075 ]]; then
+  echo "Warning: estimated ~${EST} B is within ~25 B of the ~1100 B limit." >&2
+  echo "Consider shortening candidate names or the gist filename for more margin." >&2
+fi
+
 echo "Creating branch $BRANCH..."
 
 # gh api exits non-zero on 404; test its exit status directly (no pipe race).

--- a/.claude/plugins/gov/scripts/election-pr.sh
+++ b/.claude/plugins/gov/scripts/election-pr.sh
@@ -204,10 +204,12 @@ echo "Appended election entry: $CAND_COUNT candidates, $SEATS seats."
 # discriminator, vec-length prefixes, compute-budget ixs, and batch wrapper; each
 # choice costs ~5 bytes of framing plus its name; the uri and proposal name cost
 # ~1 byte/char). It reproduces the measured sizes to the byte in the relevant range.
-NAME_LEN=${#NAME}
-GIST_LEN=${#GIST_URL}
-TAGS_CHARS=$(printf '%s' "$TAGS_JSON" | jq -r '[.[] | length] | add // 0')
-NAME_CHARS=$(jq -Rrn '[inputs | gsub("^\\s+|\\s+$"; "") | select(length > 0) | length] | add // 0' "$CANDIDATES_FILE")
+# Byte lengths (not codepoints) — the Squads limit is in bytes, so non-ASCII
+# names/tags/title must count as their UTF-8 byte size.
+NAME_LEN=$(printf %s "$NAME" | wc -c | tr -d '[:space:]')
+GIST_LEN=$(printf %s "$GIST_URL" | wc -c | tr -d '[:space:]')
+TAGS_CHARS=$(printf '%s' "$TAGS_JSON" | jq -r '[.[] | utf8bytelength] | add // 0')
+NAME_CHARS=$(jq -Rrn '[inputs | gsub("^\\s+|\\s+$"; "") | select(length > 0) | utf8bytelength] | add // 0' "$CANDIDATES_FILE")
 EST=$(( 708 + NAME_LEN + TAGS_CHARS + 5 * CAND_COUNT + NAME_CHARS + GIST_LEN ))
 echo "Pre-flight packaged-size estimate: ~${EST} bytes (Squads V4 limit ~1100)."
 if [[ "$EST" -gt 1100 ]]; then

--- a/.claude/plugins/gov/skills/election.md
+++ b/.claude/plugins/gov/skills/election.md
@@ -23,10 +23,15 @@ single For/Against proposal.
   the user one exists. The election closes on its timer and the top N win, period.
 - **Winners are derived off-chain.** The on-chain proposal only records per-choice
   weights; it does not crown winners. Tally with `tally.sh` after close.
-- **Ballot choices are names only (`uri: null`).** Per-candidate on-chain URIs do
-  not fit: all choices are serialized into one `initialize_proposal_v0`
-  instruction bounded by the 1232-byte Solana transaction limit. Candidate detail
-  lives in one combined summary gist referenced by the proposal's top-level `uri`.
+- **Ballot choices are names only (`uri: null`), and kept short.** All choices are
+  serialized into one `initialize_proposal_v0` instruction, wrapped in a Squads V4
+  vault-transaction message. The binding limit is that message's **~1100-byte
+  guard** (tighter than Solana's 1232-byte hard limit), so for ~12 choices the
+  ballot must use **plain names, not `Name (@handle)`** — handles overflow it and
+  the creation run fails (see Step 4). As a rule of thumb, 12 choices fit only if
+  the total of all choice-name characters is ≲ 140. Candidate detail and handles
+  live in the combined summary gist (the proposal's top-level `uri`), which has no
+  size limit. Always run the pre-flight size check (Step 3) before opening the PR.
 
 ## Security: untrusted content
 
@@ -106,13 +111,15 @@ list:
   --preamble /tmp/election-preamble.md \
   --out /tmp/election-summary.md \
   --names-out /tmp/candidates.txt \
-  --sort-by-name --names-with-handle
+  --sort-by-name
 ```
 
 `--sort-by-name` orders candidates alphabetically (avoids input-order position
-bias); `--names-with-handle` makes the ballot label read "Name (@handle)". Both
-the gist and `candidates.txt` come out in the same order. Confirm the order and
-label format with the user.
+bias). Ballot labels default to **plain names**; the gist body still shows each
+candidate's `(@handle)` in its section header. `--names-with-handle` would put
+handles on the ballot labels too, but for a large ballot that overflows the size
+limit (Top-N semantics), so only use it for a small ballot and only if the Step 3
+size check passes. Confirm the order and label format with the user.
 
 **Show `/tmp/election-summary.md` and `/tmp/candidates.txt` to the user and get
 explicit approval before publishing anything.** Confirm the candidate order in
@@ -123,7 +130,7 @@ explicit approval before publishing anything.** Confirm the candidate order in
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/roster-gist.sh" \
   --input /tmp/council.json --preamble /tmp/election-preamble.md \
-  --out /tmp/election-summary.md --sort-by-name --names-with-handle \
+  --out /tmp/election-summary.md --sort-by-name \
   --publish --desc "HIP-149 Advisory Council Election"
 ```
 
@@ -153,6 +160,17 @@ commits via the signed GraphQL mutation, and opens the PR. `--tags` is freeform.
 For a Mobile/IoT working-group election, pass `--file mobile-proposals.json` (or
 the relevant file) instead.
 
+`election-pr.sh` runs a **pre-flight size check** and refuses to open the PR if
+the entry's estimated packaged size exceeds the Squads V4 limit (this is what
+would otherwise fail the post-merge creation run — see Step 4). If it errors on
+size, shorten the ballot: plain names, and a short gist filename.
+
+**Verify load-bearing values with `jq`, not a summarizing fetch.** After the PR,
+confirm the entry with an exact read, e.g.
+`gh api "repos/helium/helium-vote/contents/helium-proposals.json?ref=<branch>" -H "Accept: application/vnd.github.raw" | jq '.[-1] | {maxChoicesPerVoter, choices:(.choices|length), uri}'`.
+A prose/markdown fetch summarizer misreads numeric fields like
+`maxChoicesPerVoter` and choice counts — never trust it for those.
+
 **Editing the summary after the PR is open.** The entry pins a specific gist
 revision, so if you change the summary you must re-point the entry. Update the
 gist in place, then re-point the branch (both as hiptron):
@@ -161,7 +179,7 @@ gist in place, then re-point the branch (both as hiptron):
 # 1. edit the preamble, re-render, and update the gist in place -> new pinned URL
 "${CLAUDE_PLUGIN_ROOT}/scripts/roster-gist.sh" --input /tmp/council.json \
   --preamble /tmp/election-preamble.md --out /tmp/election-summary.md \
-  --sort-by-name --names-with-handle --update-gist <GIST_ID>
+  --sort-by-name --update-gist <GIST_ID>
 
 # 2. re-point the open PR branch's entry to the new pinned URL (signed commit)
 "${CLAUDE_PLUGIN_ROOT}/scripts/repoint-uri.sh" --branch <BRANCH> \
@@ -174,22 +192,35 @@ Do this **before** on-chain creation; once voting is live the text must not chan
 
 ## Step 4 — On-chain creation (after the PR merges)
 
-Runs the same way as every governance vote — same proposer key and multisig, only
-the ballot shape differs:
+Creation is automated, not run by hand. Merging the helium-vote PR to `main`
+triggers the `create-proposals` workflow
+(`.github/workflows/create-proposals.yaml` in `helium/helium-vote`). Its
+`bulk-create-proposal` step is gated `if: github.ref == 'refs/heads/main'`, so on
+the open PR it is only a build check (the create step is skipped); it runs for
+real only after merge (push to `main`). **Never run `bulk-create-proposal` by
+hand.**
 
-- Proposer/signer: the Nova automation key
-  `propu8J469CCZuBxerEm3Yrzx1NDNSFkkn7SYD8MEyz` submits `bulk-create-proposal`
-  (in the `helium/helium-vote` repo / `create-proposals` workflow).
+- Proposer/signer: the post-merge run signs with the workflow's `DEPLOYER_KEYPAIR`
+  secret — the Nova automation key `propu8J469CCZuBxerEm3Yrzx1NDNSFkkn7SYD8MEyz` —
+  and proposes the bundle (`initializeProposalV0` + `updateStateV0 -> voting` +
+  `queueResolveProposalV0` + `addRecentProposalToDaoV0`) to the Squads multisig via
+  `sendInstructionsOrSquadsV4`.
 - Owner / org authority: the Helium governance Squads vault
-  `pULUgsYtKvT7qhsL8QJ2oJXYQUeCCdjtfawPnBqEr3U`; members approve and execute in
-  app.squads.so.
+  `pULUgsYtKvT7qhsL8QJ2oJXYQUeCCdjtfawPnBqEr3U`. The remaining human step is the
+  multisig approving to threshold and executing in app.squads.so, which opens
+  voting on heliumvote.com.
 - **Config: the Helium org default proposal config ("Helium Default V2"; its
   resolution settings are "Helium Single Choice V1", 7-day close).** No custom
   proposalConfig is needed. Its 67% / quorum thresholds are For/Against pass-bar
   logic and do not gate a top-N outcome: whatever the config records on-chain,
-  winners are the top-N by weight, derived off-chain (step 5). Before the first
-  mainnet use, confirm on a devnet dry-run how the config resolves a
-  multi-choice ballot.
+  winners are the top-N by weight, derived off-chain (step 5).
+- **If the post-merge run fails with `Failed to package instructions`,** the
+  entry's `initialize_proposal_v0` is over the Squads V4 message limit (Top-N
+  semantics above). No proposal is created — only an inert empty Squads batch, no
+  cleanup needed. Fix: shrink the entry (plain names, short gist filename) and
+  re-issue the already-merged entry with `edit-entry.sh` (exactly-once swaps off
+  `main`), then re-merge. The workflow gates on `i >= num_proposals`, so it
+  rebuilds the same index exactly once — no duplication.
 
 ## Step 5 — Announce and tally
 

--- a/.claude/plugins/gov/skills/election.md
+++ b/.claude/plugins/gov/skills/election.md
@@ -28,8 +28,9 @@ single For/Against proposal.
   vault-transaction message. The binding limit is that message's **~1100-byte
   guard** (tighter than Solana's 1232-byte hard limit), so for ~12 choices the
   ballot must use **plain names, not `Name (@handle)`** — handles overflow it and
-  the creation run fails (see Step 4). As a rule of thumb, 12 choices fit only if
-  the total of all choice-name characters is ≲ 140. Candidate detail and handles
+  the creation run fails (see Step 4). As a rule of thumb (short gist URL and title
+  assumed; the Step 3 size check is authoritative), 12 choices fit only if the
+  total of all choice-name characters is ≲ 140. Candidate detail and handles
   live in the combined summary gist (the proposal's top-level `uri`), which has no
   size limit. Always run the pre-flight size check (Step 3) before opening the PR.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ Mobile/IoT working-group elections — see `.claude/plugins/gov/skills/`:
 Top-N is a distinct mechanism from a binary HIP vote: voters approve up to N
 candidates, the N highest-weighted win, winners are derived off-chain, and the
 67% / quorum pass-bar does not apply. Ballot choices are names only (`uri: null`)
-because all choices share one transaction-size-bounded creation instruction;
+and short: all choices share one creation instruction bounded by the Squads V4
+vault-transaction message (~1100 bytes, tighter than the 1232-byte tx limit);
 candidate detail lives in the summary gist. Scripts in
 `.claude/plugins/gov/scripts/` reuse the hiptron GitHub identity.
 


### PR DESCRIPTION
Follows the HIP-149 Advisory Council election first-run failure: a 12-choice ballot with "Name (@handle)" labels overflowed the Squads V4 vault-transaction message (1257 B), so the post-merge create-proposals run failed with "Failed to package instructions" and no proposal was created.

Changes:
- **edit-entry.sh** — re-issue an already-merged proposals entry via exactly-once string swaps in one signed commit off main (used to correct the live HIP-149 entry to plain names).
- **election-pr.sh** — pre-flight packaged-size estimate, calibrated against the real @sqds/multisig serialization (reproduces the measured 1257 / 1101 / 1091 B to the byte); blocks the PR when an entry would exceed the ~1100 B Squads V4 limit.
- **election.md** — corrects Step 4 (merging the PR auto-triggers create-proposals on push-to-main; never run bulk-create-proposal by hand), documents the real Squads-V4 size limit + the "Failed to package instructions" failure and edit-entry re-issue path, defaults ballot labels to plain names (handles overflow at ~12 choices), and adds a rule to verify load-bearing fields with jq, never a summarizing fetch.